### PR TITLE
refactor : autoTagSong 언어 태그 단일 반환 및 사전 필터링 최적화 (#191)

### DIFF
--- a/.github/workflows/tagging_song.yml
+++ b/.github/workflows/tagging_song.yml
@@ -1,9 +1,9 @@
 name: Tagging Songs
 
-# on:
-#   schedule:
-#     - cron: "0 10 * * *" # 한국 시간 19:00 실행 (UTC+9 → UTC 10:00)
-#   workflow_dispatch:
+on:
+  schedule:
+    - cron: "0 10 * * *" # 한국 시간 19:00 실행 (UTC+9 → UTC 10:00)
+  workflow_dispatch:
 
 permissions:
   contents: write # push 권한을 위해 필요

--- a/packages/crawling/CLAUDE.md
+++ b/packages/crawling/CLAUDE.md
@@ -103,9 +103,10 @@ findKYByOpen.ts
 
 ### AI 유틸
 
-- `utils/validateSongMatch.ts` — `gpt-4o-mini`로 두 (제목, 아티스트) 쌍이 같은 곡인지 판단. `temperature: 0`, `max_tokens: 20`, 완전 일치 시 API 호출 생략.
+- `utils/validateSongMatch.ts` — `gpt-4o-mini`로 두 (제목, 아티스트) 쌍이 같은 곡인지 판단. `temperature: 0`, 완전 일치 시 API 호출 생략.
 - `utils/transChatGPT.ts` — `gpt-4-turbo`로 일본어 → 한국어 번역.
-- `utils/getSongTag.ts` — `gpt-4o-mini`로 곡에 적절한 태그 ID 자동 할당. DB의 `tags` 테이블에서 태그 목록을 캐싱하여 프롬프트에 포함.
+- `utils/translateJpnToKo.ts` — `gpt-5.4-mini`로 J-POP 곡 제목/아티스트 한국어 번역.
+- `utils/getSongTag.ts` — 곡에 언어 태그(100~199) 1개를 자동 할당. 한글/가나 감지 시 즉시 분류, 동일 아티스트 태그 재사용, 영문 전용 곡만 `gpt-5.4-mini`로 판별.
 
 ### 곡 태깅 파이프라인
 
@@ -113,8 +114,8 @@ findKYByOpen.ts
 taggingSongs.ts
   └─ getSongsAllDB()              # 전체 곡 조회
   └─ getSongTagSongIdsDB()        # 이미 태그된 곡 ID Set 로드 (스킵 처리)
-  └─ autoTagSong(title, artist)   # AI로 태그 ID 추출 (1~4개)
-  └─ postSongTagsDB(songId, tagIds)  # song_tags 테이블에 insert
+  └─ autoTagSong(title, artist, tagsPrompt)  # 언어 태그 1개 반환 (한글/가나 → 즉시, 영문 → LLM)
+  └─ postSongTagsDB(songId, [tagId])  # song_tags 테이블에 insert
 ```
 
 ### GitHub Actions 워크플로우

--- a/packages/crawling/src/cron/taggingSongs.ts
+++ b/packages/crawling/src/cron/taggingSongs.ts
@@ -27,18 +27,18 @@ for (const song of allSongs) {
   }
 
   try {
-    const tagIds = await autoTagSong(song.title, song.artist, tagsPrompt);
+    const tagId = await autoTagSong(song.title, song.artist, tagsPrompt);
 
-    if (tagIds.length === 0) {
+    if (tagId === null) {
       resultsLog.failed++;
       console.log(`[FAIL] ${song.title} - ${song.artist}: 태그 없음`);
       continue;
     }
 
-    const success = await postSongTagsDB(song.id, tagIds);
+    const success = await postSongTagsDB(song.id, [tagId]);
     if (success) {
       resultsLog.success++;
-      console.log(`[OK] ${song.title} - ${song.artist}: [${tagIds.join(', ')}]`);
+      console.log(`[OK] ${song.title} - ${song.artist}: [${tagId}]`);
     } else {
       resultsLog.failed++;
     }

--- a/packages/crawling/src/cron/translationJpn.ts
+++ b/packages/crawling/src/cron/translationJpn.ts
@@ -24,7 +24,6 @@ let processedCount = 0;
 for (const song of songs) {
   if (processedCount >= 5000) break;
 
-  console.log('song : ', song);
   // 이미 번역된 곡 스킵
   if (song.title_ko && song.artist_ko) {
     resultsLog.skipped++;
@@ -47,14 +46,15 @@ for (const song of songs) {
       continue;
     }
 
-    console.log('result : ', result);
-    // const success = await updateSongKoTranslationDB(song.id, result.title_ko, result.artist_ko);
-    // if (success) {
-    //   resultsLog.success++;
-    //   console.log(`[OK] ${song.title} → ${result.title_ko} / ${song.artist} → ${result.artist_ko}`);
-    // } else {
-    //   resultsLog.failed++;
-    // }
+    console.log(result);
+
+    const success = await updateSongKoTranslationDB(song.id, result.title_ko, result.artist_ko);
+    if (success) {
+      resultsLog.success++;
+      console.log(`[OK] ${song.title} → ${result.title_ko} / ${song.artist} → ${result.artist_ko}`);
+    } else {
+      resultsLog.failed++;
+    }
   } catch (error) {
     resultsLog.failed++;
     console.error(`[ERROR] ${song.title} - ${song.artist}:`, error);

--- a/packages/crawling/src/utils/getSongTag.ts
+++ b/packages/crawling/src/utils/getSongTag.ts
@@ -9,6 +9,14 @@ const client = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
+// 언어 태그 ID 범위 (100~199)
+const LANGUAGE_TAG_MIN = 100;
+const LANGUAGE_TAG_MAX = 200;
+
+// 확정 분류용 언어 태그 ID
+const TAG_KOREAN = 100;
+const TAG_JAPANESE = 101;
+
 // 태그 정보를 담을 타입 정의
 interface Tag {
   id: number;
@@ -24,6 +32,8 @@ export const getTagsForPrompt = async (): Promise<string> => {
   const { data: tags, error } = await supabase
     .from('tags')
     .select('id, name, category')
+    .gte('id', LANGUAGE_TAG_MIN)
+    .lt('id', LANGUAGE_TAG_MAX)
     .order('id');
 
   if (error) {
@@ -39,53 +49,53 @@ export const autoTagSong = async (
   title: string,
   artist: string,
   tagsPrompt: string,
-): Promise<number[]> => {
+): Promise<number | null> => {
   try {
-    if (!tagsPrompt) return [];
+    if (!tagsPrompt) return null;
 
-    // 1단계: 정규식을 이용한 문자열 사전 분석 (Harness)
-    const hasHangul = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/.test(title + artist);
-    const hasKana = /[ぁ-んァ-ヶ]/.test(title + artist);
+    const titleAndArtist = title + artist;
+    const hasHangul = /[ㄱ-ㅎㅏ-ㅣ가-힣]/.test(titleAndArtist);
+    const hasKana = /[ぁ-んァ-ヶ]/.test(titleAndArtist);
 
-    // LLM에게 줄 강력한 힌트 생성
-    const languageHints = `
-      - [Detected Script] Hangul Present: ${hasHangul}, Japanese Kana Present: ${hasKana}
-    `.trim();
+    // 1단계: 확실한 케이스는 API 호출 없이 바로 분류
+    if (hasHangul) return TAG_KOREAN;
+    if (hasKana) return TAG_JAPANESE;
 
-    // 2단계: OpenAI API 호출
+    // 2단계: 같은 아티스트의 기존 태그가 있으면 재사용
+    const supabase = getClient();
+    const { data: existingTags } = await supabase
+      .from('songs')
+      .select('song_tags!inner(tag_id)')
+      .eq('artist', artist)
+      .gte('song_tags.tag_id', LANGUAGE_TAG_MIN)
+      .lt('song_tags.tag_id', LANGUAGE_TAG_MAX)
+      .limit(1);
+
+    const existingTagId = (existingTags as { song_tags: { tag_id: number }[] }[] | null)?.[0]
+      ?.song_tags?.[0]?.tag_id;
+    if (existingTagId) return existingTagId;
+
+    // 3단계: 영문 전용 곡만 LLM으로 판별
     const response = await client.chat.completions.create({
-      model: 'gpt-4o-mini',
+      model: 'gpt-5.4-mini',
       messages: [
         {
           role: 'system',
           content: `
-            You are a music database expert specializing in global artist categorization.
+            You are a music database expert. Select EXACTLY 1 language tag for the given song.
+            The title and artist are in English/Latin script only.
 
-            [Language Selection Strategy]
-            - **Do NOT** assume a song is 102 (팝송) solely based on English/Latin characters.
-            - If title/artist are in English, research the **artist's origin and primary market**.
-            - Priority Logic:
-              1. If Hangul is detected OR the artist is a K-Pop artist: Select 100 (한국노래).
-              2. If Kana is detected OR the artist is a J-Pop/Japanese artist: Select 101 (일본노래).
-              3. Select 102 (팝송) ONLY if the artist is primarily from Western/English-speaking regions.
-              4. For all other cases or truly global/mixed origins, use 103 (글로벌).
+            [Rules]
+            - If the artist is a K-Pop/Korean artist: Select 100 (한국노래).
+            - If the artist is a J-Pop/Japanese artist: Select 101 (일본노래).
+            - If the artist is from Western/English-speaking regions: Select 102 (팝송).
+            - Otherwise: Select 103 (글로벌).
 
-            [Selection Rules]
-            - Language Slot (100-199): EXACTLY 1 tag.
-            - Genre Slot (200-299): EXACTLY 1 tag.
-            - Origin Slot (300-399): 1 to 2 tags, sorted by relevance.
-            - **Return the final result strictly in JSON format.**
+            [Output]
+            Return JSON: {"tag_id": <number>}
+            Example: {"tag_id": 102}
 
-            [Output Instructions]
-            - **Combine all selected IDs into a single flat array.**
-            - **The final output must be a JSON object with a single key "tag_ids".**
-            - **Example: {"tag_ids":}**
-            - **Do not use keys like "language", "genre", or "origin" in the JSON.**
-
-            [Contextual Hints]
-            ${languageHints}
-
-            Allowed Tags List:
+            Allowed Tags:
             ${tagsPrompt}
           `,
         },
@@ -99,12 +109,14 @@ export const autoTagSong = async (
     });
 
     const content = response.choices[0].message.content;
-    if (!content) return [];
+    if (!content) return null;
 
-    const result: { tag_ids: number[] } = JSON.parse(content);
-    return result.tag_ids;
+    const result: { tag_id: number } = JSON.parse(content);
+    return result.tag_id >= LANGUAGE_TAG_MIN && result.tag_id < LANGUAGE_TAG_MAX
+      ? result.tag_id
+      : null;
   } catch (error) {
     console.error('Error auto-tagging song:', error);
-    return [];
+    return null;
   }
 };

--- a/packages/crawling/src/utils/translateJpnToKo.ts
+++ b/packages/crawling/src/utils/translateJpnToKo.ts
@@ -18,7 +18,7 @@ export async function translateJpnToKo(
 ): Promise<TranslationResult | null> {
   try {
     const response = await client.chat.completions.create({
-      model: 'gpt-4o-mini',
+      model: 'gpt-5.4-mini',
       messages: [
         {
           role: 'system',
@@ -40,7 +40,6 @@ Rules:
       ],
       response_format: { type: 'json_object' },
       temperature: 0,
-      max_tokens: 200,
     });
 
     const content = response.choices[0].message.content;

--- a/packages/crawling/src/utils/validateSongMatch.ts
+++ b/packages/crawling/src/utils/validateSongMatch.ts
@@ -44,7 +44,6 @@ export const validateSongMatch = async (
     ],
     response_format: { type: 'json_object' },
     temperature: 0,
-    max_tokens: 50,
   });
 
   const content = response.choices[0].message.content;


### PR DESCRIPTION
## Summary

- `autoTagSong` 반환 타입을 `number[]` → `number | null`로 변경하여 언어 태그 1개만 반환하도록 리팩토링
- 한글/가나 감지 시 API 호출 없이 즉시 분류, 동일 아티스트 기존 태그 DB 재사용으로 LLM 호출 최소화
- `translationJpn` DB 업데이트 로직 활성화 및 모델 업그레이드 (gpt-4o-mini → gpt-5.4-mini)

## Changes

### autoTagSong 리팩토링
- 3단계 분류: 정규식 사전 필터링 → 아티스트 기존 태그 재사용 → LLM 판별 (영문 전용만)
- 매직 넘버 상수 추출 (`LANGUAGE_TAG_MIN`, `TAG_KOREAN` 등)
- `any` 타입 → 구체적 타입으로 교체

### 크론 스크립트 정리
- `translationJpn.ts`: DB 업데이트 로직 활성화, 디버그 로그 제거
- `taggingSongs.ts`: 단일 태그 반환에 맞게 호출부 수정

### 기타
- `max_tokens` 제한 제거 (translateJpnToKo, validateSongMatch)
- tagging 워크플로우 크론 스케줄 재활성화

## Test plan
- [ ] `pnpm lint` 통과 확인 (에러 0)
- [ ] tagging 워크플로우 수동 실행 후 정상 태깅 확인
- [ ] translationJpn 워크플로우 수동 실행 후 DB 번역 데이터 확인

Closes #191