### PR TITLE
[Feat] : 곡 카드에 title_ko / artist_ko 표시 (#197)

### DIFF
--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -179,6 +179,8 @@ export async function GET(request: Request): Promise<NextResponse<ApiResponse<Se
       id: song.id,
       title: song.title,
       artist: song.artist,
+      title_ko: song.title_ko,
+      artist_ko: song.artist_ko,
       num_tj: song.num_tj,
       num_ky: song.num_ky,
       isToSing: authenticated

--- a/apps/web/src/app/api/songs/tosing/route.ts
+++ b/apps/web/src/app/api/songs/tosing/route.ts
@@ -19,6 +19,8 @@ export async function GET(): Promise<NextResponse<ApiResponse<ToSingSong[]>>> {
           id,
           title,
           artist,
+          title_ko,
+          artist_ko,
           num_tj,
           num_ky
         )

--- a/apps/web/src/app/recent/RecentSongCard.tsx
+++ b/apps/web/src/app/recent/RecentSongCard.tsx
@@ -3,7 +3,7 @@ import { Separator } from '@/components/ui/separator';
 import { Song } from '@/types/song';
 
 export default function RecentSongCard({ song }: { song: Song }) {
-  const { title, artist, num_tj, num_ky } = song;
+  const { title, artist, title_ko, artist_ko, num_tj, num_ky } = song;
 
   return (
     <div className="w-full gap-4">
@@ -11,9 +11,15 @@ export default function RecentSongCard({ song }: { song: Song }) {
       <div className="flex flex-col">
         {/* 제목 및 가수 */}
         <div className="flex justify-between">
-          <div className="max-w-[250px] min-w-[100px]">
+          <div className="flex max-w-[250px] min-w-[100px] flex-col gap-0.5">
             <MarqueeText className="text-base font-medium">{title}</MarqueeText>
+            {title_ko && title_ko !== title && (
+              <MarqueeText className="text-muted-foreground text-xs">{title_ko}</MarqueeText>
+            )}
             <MarqueeText className="text-muted-foreground text-sm">{artist}</MarqueeText>
+            {artist_ko && artist_ko !== artist && (
+              <MarqueeText className="text-muted-foreground/70 text-xs">{artist_ko}</MarqueeText>
+            )}
           </div>
 
           <div className="flex flex-col space-x-4">

--- a/apps/web/src/app/search/SearchResultCard.tsx
+++ b/apps/web/src/app/search/SearchResultCard.tsx
@@ -42,7 +42,7 @@ export default function SearchResultCard({
   onClickSave,
   onClickArtist,
 }: IProps) {
-  const { id, title, artist, num_tj, num_ky, thumb } = song;
+  const { id, title, artist, title_ko, artist_ko, num_tj, num_ky, thumb } = song;
 
   const { isAuthenticated } = useAuthStore();
 
@@ -62,17 +62,23 @@ export default function SearchResultCard({
       {/* 메인 콘텐츠 영역 */}
       <div className="flex flex-col gap-4">
         {/* 노래 정보 */}
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-3">
           {/* 제목 및 가수 */}
           <div className="flex justify-between">
-            <div className="flex w-[calc(100%-40px)] flex-col truncate">
+            <div className="flex w-[calc(100%-40px)] flex-col gap-0.5 truncate">
               <MarqueeText className="text-base font-medium">{title}</MarqueeText>
+              {title_ko && title_ko !== title && (
+                <MarqueeText className="text-muted-foreground text-xs">{title_ko}</MarqueeText>
+              )}
               <MarqueeText
-                className="text-muted-foreground hover:text-accent cursor-pointer text-sm hover:underline hover:underline-offset-4"
+                className="text-muted-foreground hover:text-accent mt-0.5 cursor-pointer text-sm hover:underline hover:underline-offset-4"
                 onClick={onClickArtist}
               >
                 {artist}
               </MarqueeText>
+              {artist_ko && artist_ko !== artist && (
+                <MarqueeText className="text-muted-foreground/70 text-xs">{artist_ko}</MarqueeText>
+              )}
             </div>
 
             <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/web/src/app/tosing/SongCard.tsx
+++ b/apps/web/src/app/tosing/SongCard.tsx
@@ -22,6 +22,7 @@ export default function SongCard({ song, onDelete, onMoveToTop, onMoveToBottom }
   });
 
   const { title, artist, title_ko, artist_ko, num_tj, num_ky } = song;
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -30,9 +31,9 @@ export default function SongCard({ song, onDelete, onMoveToTop, onMoveToBottom }
   return (
     <Card ref={setNodeRef} style={style} className={'relative'}>
       {/* 메인 콘텐츠 영역 */}
-      <div className="flex h-[150px] w-full gap-4 p-3">
+      <div className="flex h-[180px] w-full gap-4 p-3">
         {/* 노래 정보 */}
-        <div className="mb-8 flex flex-col active:cursor-grabbing">
+        <div className="mb-10 flex flex-col justify-between active:cursor-grabbing">
           {/* 제목 및 가수 */}
           <div className="mb-1 flex w-[290px] flex-col gap-0.5">
             <MarqueeText className="text-base font-medium">{title}</MarqueeText>

--- a/apps/web/src/app/tosing/SongCard.tsx
+++ b/apps/web/src/app/tosing/SongCard.tsx
@@ -21,7 +21,7 @@ export default function SongCard({ song, onDelete, onMoveToTop, onMoveToBottom }
     id: song.id,
   });
 
-  const { title, artist, num_tj, num_ky } = song;
+  const { title, artist, title_ko, artist_ko, num_tj, num_ky } = song;
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -34,9 +34,15 @@ export default function SongCard({ song, onDelete, onMoveToTop, onMoveToBottom }
         {/* 노래 정보 */}
         <div className="mb-8 flex flex-col active:cursor-grabbing">
           {/* 제목 및 가수 */}
-          <div className="mb-1 w-[290px]">
+          <div className="mb-1 flex w-[290px] flex-col gap-0.5">
             <MarqueeText className="text-base font-medium">{title}</MarqueeText>
+            {title_ko && title_ko !== title && (
+              <MarqueeText className="text-muted-foreground text-xs">{title_ko}</MarqueeText>
+            )}
             <MarqueeText className="text-muted-foreground text-sm">{artist}</MarqueeText>
+            {artist_ko && artist_ko !== artist && (
+              <MarqueeText className="text-muted-foreground/70 text-xs">{artist_ko}</MarqueeText>
+            )}
           </div>
 
           {/* 노래방 번호 */}

--- a/apps/web/src/types/song.ts
+++ b/apps/web/src/types/song.ts
@@ -2,6 +2,9 @@ export interface Song {
   id: string;
   title: string;
   artist: string;
+  title_ko?: string;
+  artist_ko?: string;
+
   num_tj: string;
   num_ky: string;
 


### PR DESCRIPTION
## 📌 PR 제목

### [Feat] : 곡 카드에 title_ko / artist_ko 표시

## 📌 변경 사항

- `GET /api/search` 응답에 `title_ko`, `artist_ko` 필드 추가
- `Song` 타입에 `title_ko?`, `artist_ko?` 옵셔널 필드 추가
- 아래 카드에서 원어와 다른 경우에만 한국어 번역을 보조 라벨로 노출 (title 아래 / artist 아래, `text-xs` 스타일):
  - `SearchResultCard` (검색 결과)
  - `SongCard` (부를곡 목록)
  - `RecentSongCard` (최근 추가)

## 💬 추가 참고 사항

- `title_ko`/`artist_ko` 가 없거나 원어와 동일한 경우 노출하지 않음
- 각 카드의 제목/가수 컨테이너를 `flex flex-col gap-0.5` 로 정렬해 2줄 레이아웃 대응
- close #197