### PR TITLE
[Refactor] : J-POP 번역 dbArtistKoMap 초기화를 DB 직접 조회로 변경 (#199)

### DIFF
--- a/packages/crawling/src/cron/translationJpn.ts
+++ b/packages/crawling/src/cron/translationJpn.ts
@@ -1,6 +1,6 @@
 import { artistAlias } from '@repo/constants';
 
-import { getJpopSongsForTranslationDB } from '@/supabase/getDB';
+import { getArtistKoMapDB, getJpopSongsForTranslationDB } from '@/supabase/getDB';
 import { updateSongKoTranslationDB } from '@/supabase/updateDB';
 import { translateJpnToKo } from '@/utils/translateJpnToKo';
 
@@ -9,6 +9,7 @@ const resultsLog = {
   failed: 0,
   skipped: 0,
   usedAlias: 0,
+  usedDbArtist: 0,
 };
 
 // 히라가나, 카타카나, CJK 한자 범위로 일본어 포함 여부 판단
@@ -26,6 +27,10 @@ const artistAliasMap = new Map<string, string>(
 const songs = await getJpopSongsForTranslationDB();
 
 console.log('J-POP 곡 수:', songs.length);
+
+// DB 에 이미 번역된 artist → artist_ko 맵 (동일 아티스트 번역 일관성 유지 목적)
+// DB 는 아티스트당 단일 artist_ko 로 정규화되어 있으며, 번역 성공 시 런타임에도 동기화한다
+const dbArtistKoMap = await getArtistKoMapDB();
 
 let processedCount = 0;
 for (const song of songs) {
@@ -53,10 +58,14 @@ for (const song of songs) {
       continue;
     }
 
-    // artistAlias 에 등록된 아티스트면 artist_ko 를 고정 값(alias 배열 0번째)으로 덮어쓰기
+    // artist_ko 우선순위:
+    //   1) artistAlias (수동 큐레이션된 고정 값)
+    //   2) DB 에 이미 번역된 동일 아티스트의 artist_ko (번역 일관성 유지)
+    //   3) AI 번역 결과
     // title_ko 는 AI 번역 결과를 그대로 사용
     const aliasArtistKo = artistAliasMap.get(song.artist);
-    const finalArtistKo = aliasArtistKo ?? result.artist_ko;
+    const dbArtistKo = dbArtistKoMap.get(song.artist);
+    const finalArtistKo = aliasArtistKo ?? dbArtistKo ?? result.artist_ko;
 
     const success = await updateSongKoTranslationDB(song.id, result.title_ko, finalArtistKo);
     if (!success) {
@@ -64,12 +73,23 @@ for (const song of songs) {
       continue;
     }
 
+    let logPrefix: string;
     if (aliasArtistKo) {
       resultsLog.usedAlias++;
+      logPrefix = '[ALIAS]';
+    } else if (dbArtistKo) {
+      resultsLog.usedDbArtist++;
+      logPrefix = '[DB]';
     } else {
       resultsLog.success++;
+      logPrefix = '[OK]';
     }
-    const logPrefix = aliasArtistKo ? '[ALIAS]' : '[OK]';
+
+    // DB 업데이트 성공 시 런타임 맵도 동기화 (first-seen 원칙 — 기존 값 덮어쓰지 않음)
+    if (!dbArtistKoMap.has(song.artist)) {
+      dbArtistKoMap.set(song.artist, finalArtistKo);
+    }
+
     console.log(
       `${logPrefix} ${song.title} → ${result.title_ko} / ${song.artist} → ${finalArtistKo}`,
     );
@@ -90,5 +110,6 @@ console.log(`
   - 스킵 (이미 번역됨): ${resultsLog.skipped}곡
   - 성공 (AI 번역): ${resultsLog.success}곡
   - 성공 (artist_ko alias 적용): ${resultsLog.usedAlias}곡
+  - 성공 (artist_ko DB 재사용): ${resultsLog.usedDbArtist}곡
   - 실패: ${resultsLog.failed}곡
 `);

--- a/packages/crawling/src/supabase/getDB.ts
+++ b/packages/crawling/src/supabase/getDB.ts
@@ -113,6 +113,30 @@ export async function getJpopSongsForTranslationDB() {
   return data;
 }
 
+// J-POP 곡 중 이미 번역된 artist → artist_ko 맵
+// DB 는 아티스트당 단일 artist_ko 로 정규화되어 있으므로 먼저 만난 값을 사용
+export async function getArtistKoMapDB(): Promise<Map<string, string>> {
+  const supabase = getClient();
+
+  const { data, error } = await supabase
+    .from('songs')
+    .select('artist, artist_ko, song_tags!inner(tag_id)')
+    .eq('song_tags.tag_id', 101)
+    .not('artist_ko', 'is', null)
+    .limit(50000);
+
+  if (error) throw error;
+
+  const map = new Map<string, string>();
+  for (const row of data) {
+    if (!row.artist || !row.artist_ko) continue;
+    if (!map.has(row.artist)) {
+      map.set(row.artist, row.artist_ko);
+    }
+  }
+  return map;
+}
+
 export async function getSongTagSongIdsDB(): Promise<Set<string>> {
   const supabase = getClient();
 


### PR DESCRIPTION
### **User description**
## 📌 PR 제목

### [Refactor] : J-POP 번역 dbArtistKoMap 초기화를 DB 직접 조회로 변경

## 📌 변경 사항

- `@/supabase/getDB` 에 `getArtistKoMapDB()` 추가
  - `tag_id=101` + `artist_ko IS NOT NULL` 로 distinct artist→artist_ko 를 DB 에서 직접 로드
  - first-seen 원칙(Map 중복 시 덮어쓰지 않음)으로 Map 구성
- `translationJpn.ts`:
  - 배치 내 빈도 집계(`artistKoCountMap`) 로직 전부 제거
  - `dbArtistKoMap` 초기화를 `getArtistKoMapDB()` 호출로 단일화
  - 번역 성공 경로에서 `if (!has) set(finalArtistKo)` 로 런타임 맵 동기화 (alias/DB/AI 공통)
  - `[DB]` 로그 prefix 및 `usedDbArtist` 카운터 분리 추가

## 💬 추가 참고 사항

- DB 는 아티스트당 단일 `artist_ko` 로 정규화되어 있어 first-seen 로직이 안전함
- 기존 로직은 배치 내 곡들만 참조했으나, 이제 DB 전체 번역 이력을 기반으로 일관성 유지
- 동작 변경 없음: alias/DB/AI 우선순위, 스킵 조건, 결과 로그 포맷 모두 동일 (집계 방식만 변경)
- close #199


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor `dbArtistKoMap` initialization to query DB directly instead of batch-based aggregation

- Add `getArtistKoMapDB()` function to load artist translations from database

- Implement runtime map synchronization with first-seen principle

- Separate logging and metrics for DB-sourced artist translations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getArtistKoMapDB()"] -->|"Load all J-POP artist_ko"| B["dbArtistKoMap"]
  B -->|"Priority 1: Check alias"| C["aliasArtistKo"]
  B -->|"Priority 2: Check DB"| D["dbArtistKo"]
  E["AI Translation"] -->|"Priority 3: Fallback"| F["finalArtistKo"]
  C -->|"Use if exists"| F
  D -->|"Use if exists"| F
  F -->|"Sync runtime map"| B
  B -->|"Maintain consistency"| G["Updated Songs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>translationJpn.ts</strong><dd><code>Integrate DB artist map and implement priority-based translation</code></dd></summary>
<hr>

packages/crawling/src/cron/translationJpn.ts

<ul><li>Import <code>getArtistKoMapDB</code> function for database-driven initialization<br> <li> Add <code>usedDbArtist</code> counter to track DB-sourced translations<br> <li> Initialize <code>dbArtistKoMap</code> by calling <code>getArtistKoMapDB()</code> before <br>processing<br> <li> Implement three-tier priority for artist translation: alias → DB → AI<br> <li> Add runtime map synchronization using first-seen principle (no <br>overwrite)<br> <li> Separate log prefixes for alias <code>[ALIAS]</code>, DB <code>[DB]</code>, and AI <code>[OK]</code> <br>translations<br> <li> Update results summary to display DB-sourced translation count</ul>


</details>


  </td>
  <td><a href="https://github.com/GulSam00/singcode/pull/200/files#diff-8b14bd6d6914e34e34ed85123bd67aa0b8323ff3682cb9c812d418c4ceb4ede1">+25/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getDB.ts</strong><dd><code>Add database function to load artist translation map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/crawling/src/supabase/getDB.ts

<ul><li>Add new <code>getArtistKoMapDB()</code> function to fetch J-POP songs with non-null <br><code>artist_ko</code><br> <li> Query filters: <code>tag_id=101</code> (J-POP) and <code>artist_ko IS NOT NULL</code><br> <li> Build Map using first-seen principle to ensure single artist_ko per <br>artist<br> <li> Return <code>Map<string, string></code> for efficient artist-to-translation lookup</ul>


</details>


  </td>
  <td><a href="https://github.com/GulSam00/singcode/pull/200/files#diff-64d7c175e366e6ba3dcd29a7714f000216085dd3281b22084b1c7cb634d2d8b3">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

