### PR TITLE
feat: 곡 오류 신고 기능 추가 (#217)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.4",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.4",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-separator": "^1.1.2",

--- a/apps/web/public/sitemap-0.xml
+++ b/apps/web/public/sitemap-0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.singcode.kr/manifest.webmanifest</loc><lastmod>2026-05-01T01:34:01.917Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.singcode.kr</loc><lastmod>2026-05-01T01:34:01.918Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr/manifest.webmanifest</loc><lastmod>2026-05-02T12:24:19.950Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr</loc><lastmod>2026-05-02T12:24:19.952Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/web/src/app/api/songs/report/route.ts
+++ b/apps/web/src/app/api/songs/report/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+
+import createClient from '@/lib/supabase/server';
+import { ApiResponse } from '@/types/apiRoute';
+import { REPORT_CATEGORIES, ReportCategory } from '@/types/report';
+import { getAuthenticatedUser } from '@/utils/getAuthenticatedUser';
+
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+function isReportCategory(value: unknown): value is ReportCategory {
+  return typeof value === 'string' && REPORT_CATEGORIES.includes(value as ReportCategory);
+}
+
+export async function POST(request: Request): Promise<NextResponse<ApiResponse<void>>> {
+  try {
+    const supabase = await createClient();
+    const userId = await getAuthenticatedUser(supabase);
+
+    const { songId, category, suggested_value } = await request.json();
+
+    if (!songId || !category) {
+      return NextResponse.json(
+        { success: false, error: 'Missing songId or category' },
+        { status: 400 },
+      );
+    }
+
+    if (!isReportCategory(category)) {
+      return NextResponse.json({ success: false, error: 'Invalid category' }, { status: 400 });
+    }
+
+    const isNumberCategory = category === 'num_tj' || category === 'num_ky';
+
+    let normalizedSuggestedValue: string | null;
+    if (suggested_value === null) {
+      if (!isNumberCategory) {
+        return NextResponse.json(
+          { success: false, error: 'suggested_value is required for this category' },
+          { status: 400 },
+        );
+      }
+      normalizedSuggestedValue = null;
+    } else if (typeof suggested_value === 'string') {
+      const trimmed = suggested_value.trim();
+      if (!trimmed) {
+        return NextResponse.json(
+          { success: false, error: 'Missing suggested_value' },
+          { status: 400 },
+        );
+      }
+      if (isNumberCategory && !/^\d{1,5}$/.test(trimmed)) {
+        return NextResponse.json(
+          { success: false, error: 'Invalid number format' },
+          { status: 400 },
+        );
+      }
+      normalizedSuggestedValue = trimmed;
+    } else {
+      return NextResponse.json(
+        { success: false, error: 'Invalid suggested_value' },
+        { status: 400 },
+      );
+    }
+
+    const { error: insertError } = await supabase.from('song_reports').insert({
+      user_id: userId,
+      song_id: songId,
+      category,
+      suggested_value: normalizedSuggestedValue,
+    });
+
+    if (insertError) {
+      if ((insertError as { code?: string }).code === POSTGRES_UNIQUE_VIOLATION) {
+        return NextResponse.json({ success: false, error: 'Already reported' }, { status: 409 });
+      }
+      throw insertError;
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof Error && error.cause === 'auth') {
+      return NextResponse.json(
+        { success: false, error: 'User not authenticated' },
+        { status: 401 },
+      );
+    }
+    console.error('Error in report API:', error);
+    return NextResponse.json({ success: false, error: 'Failed to post report' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -21,8 +21,8 @@ export default function PrivacyPage() {
         </p>
         <p className="text-muted-foreground">
           서비스는 『개인정보 보호법』, 『정보통신망 이용촉진 및 정보보호 등에 관한 법률』 등 관련
-          법령을 준수하며, 본 개인정보처리방침을 통해 사용자의 개인정보가 어떤 방식으로 수집·이용되고
-          있는지, 어떤 보호 조치를 취하고 있는지를 안내드립니다.
+          법령을 준수하며, 본 개인정보처리방침을 통해 사용자의 개인정보가 어떤 방식으로
+          수집·이용되고 있는지, 어떤 보호 조치를 취하고 있는지를 안내드립니다.
         </p>
       </section>
 
@@ -30,7 +30,8 @@ export default function PrivacyPage() {
         <h2 className="text-lg font-semibold">개인정보의 수집·이용에 대한 동의</h2>
         <p className="text-muted-foreground">
           Singcode는 개인정보 수집 및 이용에 대한 동의를 받기 위해, 회원가입 및 소셜 로그인 시 관련
-          내용을 안내하고 사용자가 &lsquo;동의&rsquo; 버튼을 클릭한 경우에만 개인정보를 수집·이용합니다.
+          내용을 안내하고 사용자가 &lsquo;동의&rsquo; 버튼을 클릭한 경우에만 개인정보를
+          수집·이용합니다.
         </p>
       </section>
 
@@ -66,7 +67,9 @@ export default function PrivacyPage() {
 
         <div className="space-y-2">
           <p className="font-medium">4. 수집하지 않는 항목</p>
-          <p className="text-muted-foreground">서비스는 아래와 같은 민감정보는 수집하지 않습니다.</p>
+          <p className="text-muted-foreground">
+            서비스는 아래와 같은 민감정보는 수집하지 않습니다.
+          </p>
           <ul className="text-muted-foreground ml-4 list-disc space-y-1">
             <li>인종, 종교, 건강, 정치적 성향 등 민감 정보</li>
             <li>실명, 주민등록번호, 주소, 전화번호 등 신원 확인 정보</li>

--- a/apps/web/src/app/search/SearchResultCard.tsx
+++ b/apps/web/src/app/search/SearchResultCard.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   ChevronDown,
+  Flag,
   ListPlus,
   ListRestart,
   MinusCircle,
@@ -12,6 +13,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 
 import MarqueeText from '@/components/MarqueeText';
+import ReportSongModal from '@/components/ReportSongModal';
 import ThumbUpModal from '@/components/ThumbUpModal';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -47,6 +49,7 @@ export default function SearchResultCard({
   const { isAuthenticated } = useAuthStore();
 
   const [open, setOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleClickThumbsUp = () => {
@@ -55,6 +58,14 @@ export default function SearchResultCard({
       return;
     }
     setOpen(true);
+  };
+
+  const handleClickReport = () => {
+    if (!isAuthenticated) {
+      toast.error('로그인하고 오류 신고에 참여해주세요!');
+      return;
+    }
+    setReportOpen(true);
   };
 
   return (
@@ -66,18 +77,20 @@ export default function SearchResultCard({
           {/* 제목 및 가수 */}
           <div className="flex justify-between">
             <div className="flex w-[calc(100%-40px)] flex-col gap-0.5 truncate">
-              <MarqueeText className="text-base font-medium">{title}</MarqueeText>
+              <MarqueeText className="text-base font-medium">
+                {title_ko && title_ko !== title ? title_ko : title}
+              </MarqueeText>
               {title_ko && title_ko !== title && (
-                <MarqueeText className="text-muted-foreground text-xs">{title_ko}</MarqueeText>
+                <MarqueeText className="text-muted-foreground text-xs">{title}</MarqueeText>
               )}
               <MarqueeText
                 className="text-muted-foreground hover:text-accent mt-0.5 cursor-pointer text-sm hover:underline hover:underline-offset-4"
                 onClick={onClickArtist}
               >
-                {artist}
+                {artist_ko && artist_ko !== artist ? artist_ko : artist}
               </MarqueeText>
               {artist_ko && artist_ko !== artist && (
-                <MarqueeText className="text-muted-foreground/70 text-xs">{artist_ko}</MarqueeText>
+                <MarqueeText className="text-muted-foreground/70 text-xs">{artist}</MarqueeText>
               )}
             </div>
 
@@ -181,10 +194,36 @@ export default function SearchResultCard({
                   {isSave ? <ListRestart className="h-5 w-5" /> : <ListPlus className="h-5 w-5" />}
                   <span className="text-xs">{isSave ? '재생목록 수정' : '재생목록 추가'}</span>
                 </Button>
+
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-13 flex-1 flex-col items-center justify-center"
+                  aria-label="오류 신고"
+                  onClick={handleClickReport}
+                >
+                  <Flag className="h-5 w-5" />
+                  <span className="text-xs">오류 신고</span>
+                </Button>
               </div>
             </motion.div>
           )}
         </AnimatePresence>
+
+        <Dialog open={reportOpen} onOpenChange={setReportOpen}>
+          <DialogContent>
+            <ReportSongModal
+              songId={id}
+              title={title}
+              artist={artist}
+              title_ko={title_ko}
+              artist_ko={artist_ko}
+              num_tj={num_tj}
+              num_ky={num_ky}
+              handleClose={() => setReportOpen(false)}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </Card>
   );

--- a/apps/web/src/components/ReportSongModal.tsx
+++ b/apps/web/src/components/ReportSongModal.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { useReportSongMutation } from '@/queries/reportSongQuery';
+import { REPORT_CATEGORIES, REPORT_CATEGORY_LABEL, ReportCategory } from '@/types/report';
+import { cn } from '@/utils/cn';
+
+interface ReportSongModalProps {
+  songId: string;
+  title: string;
+  artist: string;
+  title_ko?: string;
+  artist_ko?: string;
+  num_tj?: string;
+  num_ky?: string;
+  handleClose: () => void;
+}
+
+const SUGGESTED_VALUE_TEXT_MAX_LENGTH = 100;
+const SUGGESTED_VALUE_NUMBER_MAX_LENGTH = 5;
+const NO_DATA_LABEL = '데이터 없음';
+
+type CardField = 'artist' | 'title' | 'num_tj' | 'num_ky';
+
+const CATEGORY_TO_FIELD: Record<ReportCategory, CardField> = {
+  artist_translation: 'artist',
+  title_translation: 'title',
+  num_tj: 'num_tj',
+  num_ky: 'num_ky',
+};
+
+const isNumberCategory = (value: ReportCategory | null) => value === 'num_tj' || value === 'num_ky';
+
+function splitDisplay(
+  translated: string | undefined,
+  original: string,
+): { primary: string; secondary: string | null; display: string } {
+  if (translated && translated !== original) {
+    return {
+      primary: translated,
+      secondary: original,
+      display: `${translated} (${original})`,
+    };
+  }
+  return { primary: original, secondary: null, display: original };
+}
+
+function NewValueIndicator({
+  isVisible,
+  value,
+  textSize,
+}: {
+  isVisible: boolean;
+  value: string | null;
+  textSize: 'text-base' | 'text-sm';
+}) {
+  return (
+    <>
+      <span className={cn('text-muted-foreground shrink-0', !isVisible && 'invisible')}>→</span>
+      <span
+        className={cn(
+          'text-primary min-w-0 truncate font-medium',
+          textSize,
+          !isVisible && 'invisible',
+        )}
+      >
+        {value ?? ' '}
+      </span>
+    </>
+  );
+}
+
+export default function ReportSongModal({
+  songId,
+  title,
+  artist,
+  title_ko,
+  artist_ko,
+  num_tj,
+  num_ky,
+  handleClose,
+}: ReportSongModalProps) {
+  const titleParts = splitDisplay(title_ko, title);
+  const artistParts = splitDisplay(artist_ko, artist);
+
+  const [category, setCategory] = useState<ReportCategory | null>(null);
+  const [suggestedValue, setSuggestedValue] = useState('');
+  const [isNoData, setIsNoData] = useState(false);
+
+  const { mutate: reportSong, isPending } = useReportSongMutation();
+
+  const isNumberMode = isNumberCategory(category);
+  const inputMaxLength = isNumberMode
+    ? SUGGESTED_VALUE_NUMBER_MAX_LENGTH
+    : SUGGESTED_VALUE_TEXT_MAX_LENGTH;
+
+  const handleCategoryChange = (value: ReportCategory) => {
+    setCategory(value);
+    setSuggestedValue('');
+    setIsNoData(false);
+  };
+
+  const handleSuggestedValueChange = (value: string) => {
+    if (isNumberMode) {
+      const digitsOnly = value.replace(/\D/g, '').slice(0, SUGGESTED_VALUE_NUMBER_MAX_LENGTH);
+      setSuggestedValue(digitsOnly);
+    } else {
+      setSuggestedValue(value);
+    }
+  };
+
+  const handleNoDataChange = (checked: boolean) => {
+    setIsNoData(checked);
+    setSuggestedValue('');
+  };
+
+  const handleSubmit = () => {
+    if (!category) {
+      toast.error('신고 항목을 선택해주세요.');
+      return;
+    }
+    const trimmedSuggestedValue = suggestedValue.trim();
+    if (!isNoData && !trimmedSuggestedValue) {
+      toast.error('올바른 정보를 입력해주세요.');
+      return;
+    }
+    reportSong(
+      {
+        songId,
+        category,
+        suggested_value: isNoData ? null : trimmedSuggestedValue,
+      },
+      {
+        onSuccess: () => {
+          handleClose();
+        },
+      },
+    );
+  };
+
+  const activeField = category ? CATEGORY_TO_FIELD[category] : null;
+  const newValue = isNoData ? NO_DATA_LABEL : suggestedValue.trim() || null;
+
+  const isFieldActive = (field: CardField) => activeField === field && newValue !== null;
+
+  return (
+    <div className="flex flex-col gap-4 sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>오류 신고</DialogTitle>
+        <DialogDescription className="sr-only">
+          {titleParts.display} - {artistParts.display} 곡에 대한 오류 신고
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-4">
+        <RadioGroup
+          value={category ?? undefined}
+          onValueChange={value => handleCategoryChange(value as ReportCategory)}
+          className="grid grid-cols-2 gap-2"
+          aria-label="신고 항목"
+        >
+          {REPORT_CATEGORIES.map(value => (
+            <Label
+              key={value}
+              htmlFor={`report-${value}`}
+              className="hover:bg-muted/40 has-checked:border-primary has-checked:bg-primary/5 flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors"
+            >
+              <RadioGroupItem value={value} id={`report-${value}`} />
+              <span className="text-sm">{REPORT_CATEGORY_LABEL[value]}</span>
+            </Label>
+          ))}
+        </RadioGroup>
+
+        <div className="flex flex-col gap-3 rounded-md border p-4">
+          <div className="flex flex-col gap-1">
+            <div
+              className={cn(
+                'rounded-sm px-2 py-1 transition-colors',
+                activeField === 'title' && 'bg-primary/10',
+              )}
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="min-w-0 truncate text-base font-medium">
+                    {titleParts.primary}
+                  </span>
+                  <NewValueIndicator
+                    isVisible={isFieldActive('title')}
+                    value={newValue}
+                    textSize="text-base"
+                  />
+                </div>
+                {titleParts.secondary && (
+                  <span className="text-muted-foreground truncate text-xs">
+                    {titleParts.secondary}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                'rounded-sm px-2 py-1 transition-colors',
+                activeField === 'artist' && 'bg-primary/10',
+              )}
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="text-muted-foreground min-w-0 truncate text-sm">
+                    {artistParts.primary}
+                  </span>
+                  <NewValueIndicator
+                    isVisible={isFieldActive('artist')}
+                    value={newValue}
+                    textSize="text-sm"
+                  />
+                </div>
+                {artistParts.secondary && (
+                  <span className="text-muted-foreground/70 truncate text-xs">
+                    {artistParts.secondary}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex gap-2 border-t pt-2">
+            <div
+              className={cn(
+                'flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 transition-colors',
+                activeField === 'num_tj' && 'bg-primary/10',
+              )}
+            >
+              <span className="text-brand-tj shrink-0 text-xs font-bold">TJ</span>
+              <span className="min-w-0 truncate text-sm font-medium">{num_tj || '-'}</span>
+              <NewValueIndicator
+                isVisible={isFieldActive('num_tj')}
+                value={newValue}
+                textSize="text-sm"
+              />
+            </div>
+            <div
+              className={cn(
+                'flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 transition-colors',
+                activeField === 'num_ky' && 'bg-primary/10',
+              )}
+            >
+              <span className="text-brand-ky shrink-0 text-xs font-bold">금영</span>
+              <span className="min-w-0 truncate text-sm font-medium">{num_ky || '-'}</span>
+              <NewValueIndicator
+                isVisible={isFieldActive('num_ky')}
+                value={newValue}
+                textSize="text-sm"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="report-suggested-value">올바른 정보</Label>
+          <Input
+            id="report-suggested-value"
+            placeholder={
+              isNumberMode
+                ? '5자리 숫자로 입력해주세요.'
+                : '어떤 내용으로 바뀌어야 하는지 적어주세요.'
+            }
+            value={isNoData ? NO_DATA_LABEL : suggestedValue}
+            onChange={e => handleSuggestedValueChange(e.target.value)}
+            maxLength={inputMaxLength}
+            inputMode={isNumberMode ? 'numeric' : undefined}
+            pattern={isNumberMode ? '[0-9]*' : undefined}
+            disabled={isNoData}
+            required
+          />
+          <Label
+            htmlFor="report-no-data"
+            className={cn(
+              'text-muted-foreground flex items-center gap-2 text-sm',
+              isNumberMode ? 'cursor-pointer' : 'invisible',
+            )}
+            aria-hidden={!isNumberMode}
+          >
+            <Checkbox
+              id="report-no-data"
+              checked={isNoData}
+              onCheckedChange={checked => handleNoDataChange(checked === true)}
+              disabled={!isNumberMode}
+              tabIndex={isNumberMode ? 0 : -1}
+            />
+            데이터 없음 (해당 노래방에 등록되지 않은 곡)
+          </Label>
+          <div className={cn('text-muted-foreground self-end text-xs', isNoData && 'invisible')}>
+            {suggestedValue.length} / {inputMaxLength}
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter className="gap-2 sm:gap-2">
+        <Button variant="outline" onClick={handleClose} disabled={isPending}>
+          취소
+        </Button>
+        <Button onClick={handleSubmit} disabled={isPending}>
+          {isPending ? '제출 중...' : '제출'}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { CircleIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/utils/cn';
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn('grid gap-3', className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/apps/web/src/lib/api/reportSong.ts
+++ b/apps/web/src/lib/api/reportSong.ts
@@ -1,0 +1,15 @@
+import { ApiResponse } from '@/types/apiRoute';
+import { ReportCategory } from '@/types/report';
+
+import { instance } from './client';
+
+export interface PostSongReportBody {
+  songId: string;
+  category: ReportCategory;
+  suggested_value: string | null;
+}
+
+export async function postSongReport(body: PostSongReportBody) {
+  const response = await instance.post<ApiResponse<void>>('/songs/report', body);
+  return response.data;
+}

--- a/apps/web/src/queries/reportSongQuery.ts
+++ b/apps/web/src/queries/reportSongQuery.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { toast } from 'sonner';
+
+import { PostSongReportBody, postSongReport } from '@/lib/api/reportSong';
+
+export const useReportSongMutation = () => {
+  return useMutation({
+    mutationFn: (body: PostSongReportBody) => postSongReport(body),
+    onSuccess: () => {
+      toast.success('신고가 접수되었습니다.');
+    },
+    onError: error => {
+      console.error('Report error:', error);
+      if (error instanceof AxiosError && error.response?.status === 409) {
+        toast.error('이미 신고하신 항목입니다.');
+        return;
+      }
+      const message = error instanceof Error ? error.message : '신고 접수 실패';
+      toast.error(message);
+    },
+  });
+};

--- a/apps/web/src/types/report.ts
+++ b/apps/web/src/types/report.ts
@@ -1,0 +1,25 @@
+export type ReportCategory = 'artist_translation' | 'title_translation' | 'num_tj' | 'num_ky';
+
+export const REPORT_CATEGORIES: ReportCategory[] = [
+  'title_translation',
+  'artist_translation',
+  'num_tj',
+  'num_ky',
+];
+
+export const REPORT_CATEGORY_LABEL: Record<ReportCategory, string> = {
+  title_translation: '제목 번역',
+  artist_translation: '가수 번역',
+  num_tj: 'TJ 번호',
+  num_ky: '금영 번호',
+};
+
+export type ReportStatus = 'pending' | 'applied' | 'rejected';
+
+export const REPORT_STATUSES: ReportStatus[] = ['pending', 'applied', 'rejected'];
+
+export const REPORT_STATUS_LABEL: Record<ReportStatus, string> = {
+  pending: '대기중',
+  applied: '반영됨',
+  rejected: '거절됨',
+};

--- a/apps/web/src/utils/getArtistAlias.ts
+++ b/apps/web/src/utils/getArtistAlias.ts
@@ -1,5 +1,6 @@
-import { artistAlias } from '@repo/constants';
 import { getChoseong } from 'es-hangul';
+
+import { artistAlias } from '@repo/constants';
 
 export type SearchCandidate = { label: string; value: string };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.4
         version: 2.1.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.4
         version: 1.2.10(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1508,6 +1511,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6593,6 +6609,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.10)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.10)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.10)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.0.10)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.10)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- 검색 결과 카드에 오류 신고 모달 추가 — 가수 번역 / 곡 번역 / TJ 번호 / 금영 번호 4가지 카테고리
- 라이브 미리보기: 선택한 카테고리 행이 강조되고 입력값이 `원본 → 새 값` 형태로 즉시 반영
- 숫자 카테고리 (`num_tj` / `num_ky`)는 5자리 숫자만 입력 가능, 「데이터 없음」 체크박스로 `suggested_value: null` 제출
- BFF: `POST /api/songs/report` → Supabase `song_reports` 테이블 insert
- TanStack Query mutation 훅 (`useReportSongMutation`) + `ReportCategory` / `ReportStatus` 타입 정의

## DB 작업 필요
```sql
ALTER TABLE song_reports ALTER COLUMN suggested_value DROP NOT NULL;
ALTER TABLE song_reports
  ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'
  CHECK (status IN ('pending', 'applied', 'rejected'));
```
※ `status` 컬럼은 다음 작업 (info 페이지 신고 목록/삭제)에서 활용 예정

## Test plan
- [ ] 비로그인 상태에서 신고 버튼 → 로그인 유도 토스트
- [ ] 카테고리 미선택 제출 → "신고 항목을 선택해주세요" 토스트
- [ ] 텍스트 카테고리 (가수/곡 번역): 100자 제한, 빈 입력 거부
- [ ] 숫자 카테고리 (TJ/금영): 숫자만 입력, 5자 제한, 「데이터 없음」 체크 시 input disabled + null 제출
- [ ] 카테고리 전환 시 입력값/체크박스 초기화
- [ ] 카드 미리보기: 선택 항목 강조 + `→ 새 값` 표시, 입력 후 토글 시 모달 높이 변동 없음
- [ ] 중복 신고 시 409 에러 → "이미 신고하신 항목입니다" 토스트

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)