### PR TITLE
feat : 내 신고 내역 확인 및 삭제 페이지 추가 (#219)

### DIFF
--- a/apps/web/public/sitemap-0.xml
+++ b/apps/web/public/sitemap-0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.singcode.kr/manifest.webmanifest</loc><lastmod>2026-05-02T12:24:19.950Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.singcode.kr</loc><lastmod>2026-05-02T12:24:19.952Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr/manifest.webmanifest</loc><lastmod>2026-05-02T15:28:30.385Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr</loc><lastmod>2026-05-02T15:28:30.386Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/web/src/app/api/songs/report/route.ts
+++ b/apps/web/src/app/api/songs/report/route.ts
@@ -2,13 +2,104 @@ import { NextResponse } from 'next/server';
 
 import createClient from '@/lib/supabase/server';
 import { ApiResponse } from '@/types/apiRoute';
-import { REPORT_CATEGORIES, ReportCategory } from '@/types/report';
+import { MyReport, REPORT_CATEGORIES, ReportCategory, ReportStatus } from '@/types/report';
+import { Song } from '@/types/song';
 import { getAuthenticatedUser } from '@/utils/getAuthenticatedUser';
 
 const POSTGRES_UNIQUE_VIOLATION = '23505';
 
 function isReportCategory(value: unknown): value is ReportCategory {
   return typeof value === 'string' && REPORT_CATEGORIES.includes(value as ReportCategory);
+}
+
+interface ReportRow {
+  id: string;
+  song_id: string;
+  category: ReportCategory;
+  suggested_value: string | null;
+  status: ReportStatus;
+  created_at: string;
+  songs: Pick<Song, 'title' | 'artist' | 'title_ko' | 'artist_ko' | 'num_tj' | 'num_ky'> | null;
+}
+
+export async function GET(): Promise<NextResponse<ApiResponse<MyReport[]>>> {
+  try {
+    const supabase = await createClient();
+    const userId = await getAuthenticatedUser(supabase);
+
+    const { data, error } = await supabase
+      .from('song_reports')
+      .select(
+        `id, song_id, category, suggested_value, status, created_at,
+         songs ( title, artist, title_ko, artist_ko, num_tj, num_ky )`,
+      )
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .returns<ReportRow[]>();
+
+    if (error) throw error;
+
+    const reports: MyReport[] = (data ?? []).map(row => ({
+      id: row.id,
+      song_id: row.song_id,
+      category: row.category,
+      suggested_value: row.suggested_value,
+      status: row.status,
+      created_at: row.created_at,
+      title: row.songs?.title ?? '',
+      artist: row.songs?.artist ?? '',
+      title_ko: row.songs?.title_ko,
+      artist_ko: row.songs?.artist_ko,
+      num_tj: row.songs?.num_tj ?? '',
+      num_ky: row.songs?.num_ky ?? '',
+    }));
+
+    return NextResponse.json({ success: true, data: reports });
+  } catch (error) {
+    if (error instanceof Error && error.cause === 'auth') {
+      return NextResponse.json(
+        { success: false, error: 'User not authenticated' },
+        { status: 401 },
+      );
+    }
+    console.error('Error in report GET API:', error);
+    return NextResponse.json({ success: false, error: 'Failed to get reports' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request): Promise<NextResponse<ApiResponse<void>>> {
+  try {
+    const supabase = await createClient();
+    const userId = await getAuthenticatedUser(supabase);
+
+    const { reportId } = await request.json();
+
+    if (!reportId || typeof reportId !== 'string') {
+      return NextResponse.json({ success: false, error: 'Missing reportId' }, { status: 400 });
+    }
+
+    const { error, count } = await supabase
+      .from('song_reports')
+      .delete({ count: 'exact' })
+      .match({ id: reportId, user_id: userId });
+
+    if (error) throw error;
+
+    if (count === 0) {
+      return NextResponse.json({ success: false, error: 'Report not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof Error && error.cause === 'auth') {
+      return NextResponse.json(
+        { success: false, error: 'User not authenticated' },
+        { status: 401 },
+      );
+    }
+    console.error('Error in report DELETE API:', error);
+    return NextResponse.json({ success: false, error: 'Failed to delete report' }, { status: 500 });
+  }
 }
 
 export async function POST(request: Request): Promise<NextResponse<ApiResponse<void>>> {

--- a/apps/web/src/app/info/page.tsx
+++ b/apps/web/src/app/info/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CircleDollarSign, Folder, Star } from 'lucide-react';
+import { CircleDollarSign, Flag, Folder, Star } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 import CountUp from '@/components/reactBits/CountUp';
@@ -21,6 +21,12 @@ const menuItems = [
     title: '재생목록 관리',
     description: '재생목록을 관리합니다',
     icon: <Folder className="h-5 w-5" />,
+  },
+  {
+    id: 'reports',
+    title: '내 신고 내역',
+    description: '내가 신고한 곡 오류를 확인하고 삭제합니다',
+    icon: <Flag className="h-5 w-5" />,
   },
 ];
 

--- a/apps/web/src/app/info/reports/DeleteReportModal.tsx
+++ b/apps/web/src/app/info/reports/DeleteReportModal.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useDeleteMyReportMutation } from '@/queries/reportSongQuery';
+import { MyReport, REPORT_CATEGORY_LABEL } from '@/types/report';
+
+interface DeleteReportModalProps {
+  isOpen: boolean;
+  report: MyReport | null;
+  onClose: () => void;
+}
+
+export default function DeleteReportModal({ isOpen, report, onClose }: DeleteReportModalProps) {
+  const { mutate: deleteReport, isPending } = useDeleteMyReportMutation();
+
+  const handleDelete = () => {
+    if (!report) return;
+    deleteReport(report.id, {
+      onSuccess: () => {
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && !isPending && onClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Trash2 className="h-5 w-5" />
+            신고 내역 삭제
+          </DialogTitle>
+          <DialogDescription>
+            {report
+              ? `${report.title || '해당 곡'} - ${REPORT_CATEGORY_LABEL[report.category]} 신고를 삭제합니다.`
+              : '신고 내역을 삭제합니다.'}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-2">
+          <p className="text-muted-foreground text-center text-sm">
+            정말 삭제하시겠습니까?
+            <br />이 작업은 되돌릴 수 없습니다.
+          </p>
+        </div>
+        <DialogFooter className="flex space-x-2">
+          <Button variant="outline" onClick={onClose} disabled={isPending}>
+            취소
+          </Button>
+          <Button onClick={handleDelete} disabled={isPending} variant="destructive">
+            {isPending ? '삭제 중...' : '삭제'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/info/reports/ReportItem.tsx
+++ b/apps/web/src/app/info/reports/ReportItem.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+
+import ReportFieldCard from '@/components/ReportFieldCard';
+import { Button } from '@/components/ui/button';
+import {
+  MyReport,
+  REPORT_CATEGORY_LABEL,
+  REPORT_CATEGORY_TO_FIELD,
+  REPORT_NO_DATA_LABEL,
+  REPORT_STATUS_LABEL,
+  ReportCategory,
+  ReportStatus,
+} from '@/types/report';
+import { cn } from '@/utils/cn';
+
+interface ReportItemProps {
+  report: MyReport;
+  onDelete: (report: MyReport) => void;
+  isDisabled?: boolean;
+}
+
+const STATUS_BADGE_CLASS: Record<ReportStatus, string> = {
+  pending:
+    'border border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300',
+  applied:
+    'border border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
+  rejected:
+    'border border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300',
+};
+
+const CATEGORY_BADGE_CLASS: Record<ReportCategory, string> = {
+  title_translation:
+    'border border-sky-300 bg-sky-50 text-sky-700 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-300',
+  artist_translation:
+    'border border-pink-300 bg-pink-50 text-pink-700 dark:border-pink-800 dark:bg-pink-950 dark:text-pink-300',
+  num_tj: 'border border-brand-tj/40 bg-brand-tj/10 text-brand-tj',
+  num_ky: 'border border-brand-ky/40 bg-brand-ky/10 text-brand-ky',
+};
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}.${mm}.${dd}`;
+}
+
+export default function ReportItem({ report, onDelete, isDisabled }: ReportItemProps) {
+  const activeField = REPORT_CATEGORY_TO_FIELD[report.category];
+  const newValue = report.suggested_value ?? REPORT_NO_DATA_LABEL;
+
+  return (
+    <div className="border-border border-b py-3 last:border-0">
+      <div className="mb-2 flex items-center gap-2 pr-4">
+        <span
+          className={cn(
+            'rounded-full px-2 py-0.5 text-xs font-medium',
+            STATUS_BADGE_CLASS[report.status],
+          )}
+        >
+          {REPORT_STATUS_LABEL[report.status]}
+        </span>
+        <span
+          className={cn(
+            'rounded-full px-2 py-0.5 text-xs font-medium',
+            CATEGORY_BADGE_CLASS[report.category],
+          )}
+        >
+          {REPORT_CATEGORY_LABEL[report.category]}
+        </span>
+        <span className="text-muted-foreground ml-auto text-xs">
+          {formatDate(report.created_at)}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={() => onDelete(report)}
+          disabled={isDisabled}
+          aria-label="신고 삭제"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <ReportFieldCard
+        title={report.title}
+        artist={report.artist}
+        title_ko={report.title_ko}
+        artist_ko={report.artist_ko}
+        num_tj={report.num_tj}
+        num_ky={report.num_ky}
+        activeField={activeField}
+        newValue={newValue}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/info/reports/page.tsx
+++ b/apps/web/src/app/info/reports/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import StaticLoading from '@/components/StaticLoading';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { useMyReportsQuery } from '@/queries/reportSongQuery';
+import useAuthStore from '@/stores/useAuthStore';
+import { MyReport } from '@/types/report';
+
+import DeleteReportModal from './DeleteReportModal';
+import ReportItem from './ReportItem';
+
+export default function MyReportsPage() {
+  const router = useRouter();
+  const { isAuthenticated } = useAuthStore();
+  const { data, isLoading } = useMyReportsQuery(isAuthenticated);
+  const reports = data ?? [];
+
+  const [targetReport, setTargetReport] = useState<MyReport | null>(null);
+
+  return (
+    <div className="bg-background h-full">
+      {isLoading && <StaticLoading />}
+      <div className="flex items-center">
+        <Button variant="ghost" size="icon" onClick={() => router.back()} className="mr-2">
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <h1 className="text-2xl font-bold">내 신고 내역</h1>
+      </div>
+
+      <div className="flex h-[48px] items-center justify-between p-2">
+        <p className="text-muted-foreground text-sm">총 {reports.length}건</p>
+      </div>
+
+      <Separator className="mb-4" />
+
+      <ScrollArea className="h-[calc(100vh-20rem)]">
+        {reports.length === 0 && !isLoading ? (
+          <div className="text-muted-foreground py-8 text-center text-sm">
+            <p className="mb-2">신고한 내역이 없습니다.</p>
+            <p>곡 정보 오류를 발견하면 검색 결과에서 신고할 수 있어요.</p>
+          </div>
+        ) : (
+          reports.map(report => (
+            <ReportItem key={report.id} report={report} onDelete={setTargetReport} />
+          ))
+        )}
+      </ScrollArea>
+
+      <DeleteReportModal
+        isOpen={targetReport !== null}
+        report={targetReport}
+        onClose={() => setTargetReport(null)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/ReportFieldCard.tsx
+++ b/apps/web/src/components/ReportFieldCard.tsx
@@ -1,0 +1,147 @@
+import { ReportCardField } from '@/types/report';
+import { cn } from '@/utils/cn';
+
+interface ReportFieldCardProps {
+  title: string;
+  artist: string;
+  title_ko?: string;
+  artist_ko?: string;
+  num_tj?: string;
+  num_ky?: string;
+  activeField: ReportCardField | null;
+  newValue: string | null;
+}
+
+function splitDisplay(
+  translated: string | undefined,
+  original: string,
+): { primary: string; secondary: string | null } {
+  if (translated && translated !== original) {
+    return { primary: translated, secondary: original };
+  }
+  return { primary: original || '-', secondary: null };
+}
+
+function NewValueIndicator({
+  isVisible,
+  value,
+  textSize,
+}: {
+  isVisible: boolean;
+  value: string | null;
+  textSize: 'text-base' | 'text-sm';
+}) {
+  return (
+    <>
+      <span className={cn('text-muted-foreground shrink-0', !isVisible && 'invisible')}>→</span>
+      <span
+        className={cn(
+          'text-primary min-w-0 truncate font-medium',
+          textSize,
+          !isVisible && 'invisible',
+        )}
+      >
+        {value ?? ' '}
+      </span>
+    </>
+  );
+}
+
+export default function ReportFieldCard({
+  title,
+  artist,
+  title_ko,
+  artist_ko,
+  num_tj,
+  num_ky,
+  activeField,
+  newValue,
+}: ReportFieldCardProps) {
+  const titleParts = splitDisplay(title_ko, title);
+  const artistParts = splitDisplay(artist_ko, artist);
+
+  const isFieldActive = (field: ReportCardField) => activeField === field && newValue !== null;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border p-3">
+      <div className="flex flex-col gap-1">
+        <div
+          className={cn(
+            'rounded-sm px-2 py-1 transition-colors',
+            isFieldActive('title') && 'bg-primary/10',
+          )}
+        >
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="min-w-0 truncate text-base font-medium">{titleParts.primary}</span>
+              <NewValueIndicator
+                isVisible={isFieldActive('title')}
+                value={newValue}
+                textSize="text-base"
+              />
+            </div>
+            {titleParts.secondary && (
+              <span className="text-muted-foreground truncate text-xs">{titleParts.secondary}</span>
+            )}
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            'rounded-sm px-2 py-1 transition-colors',
+            isFieldActive('artist') && 'bg-primary/10',
+          )}
+        >
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="text-muted-foreground min-w-0 truncate text-sm">
+                {artistParts.primary}
+              </span>
+              <NewValueIndicator
+                isVisible={isFieldActive('artist')}
+                value={newValue}
+                textSize="text-sm"
+              />
+            </div>
+            {artistParts.secondary && (
+              <span className="text-muted-foreground/70 truncate text-xs">
+                {artistParts.secondary}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-2 border-t pt-2">
+        <div
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 transition-colors',
+            isFieldActive('num_tj') && 'bg-primary/10',
+          )}
+        >
+          <span className="text-brand-tj shrink-0 text-xs font-bold">TJ</span>
+          <span className="min-w-0 truncate text-sm font-medium">{num_tj || '-'}</span>
+          <NewValueIndicator
+            isVisible={isFieldActive('num_tj')}
+            value={newValue}
+            textSize="text-sm"
+          />
+        </div>
+        <div
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 transition-colors',
+            isFieldActive('num_ky') && 'bg-primary/10',
+          )}
+        >
+          <span className="text-brand-ky shrink-0 text-xs font-bold">금영</span>
+          <span className="min-w-0 truncate text-sm font-medium">{num_ky || '-'}</span>
+          <NewValueIndicator
+            isVisible={isFieldActive('num_ky')}
+            value={newValue}
+            textSize="text-sm"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ReportSongModal.tsx
+++ b/apps/web/src/components/ReportSongModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 
+import ReportFieldCard from '@/components/ReportFieldCard';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -10,7 +11,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { useReportSongMutation } from '@/queries/reportSongQuery';
-import { REPORT_CATEGORIES, REPORT_CATEGORY_LABEL, ReportCategory } from '@/types/report';
+import {
+  REPORT_CATEGORIES,
+  REPORT_CATEGORY_LABEL,
+  REPORT_CATEGORY_TO_FIELD,
+  REPORT_NO_DATA_LABEL,
+  ReportCategory,
+} from '@/types/report';
 import { cn } from '@/utils/cn';
 
 interface ReportSongModalProps {
@@ -26,56 +33,14 @@ interface ReportSongModalProps {
 
 const SUGGESTED_VALUE_TEXT_MAX_LENGTH = 100;
 const SUGGESTED_VALUE_NUMBER_MAX_LENGTH = 5;
-const NO_DATA_LABEL = '데이터 없음';
-
-type CardField = 'artist' | 'title' | 'num_tj' | 'num_ky';
-
-const CATEGORY_TO_FIELD: Record<ReportCategory, CardField> = {
-  artist_translation: 'artist',
-  title_translation: 'title',
-  num_tj: 'num_tj',
-  num_ky: 'num_ky',
-};
 
 const isNumberCategory = (value: ReportCategory | null) => value === 'num_tj' || value === 'num_ky';
 
-function splitDisplay(
-  translated: string | undefined,
-  original: string,
-): { primary: string; secondary: string | null; display: string } {
+function getDisplay(translated: string | undefined, original: string): string {
   if (translated && translated !== original) {
-    return {
-      primary: translated,
-      secondary: original,
-      display: `${translated} (${original})`,
-    };
+    return `${translated} (${original})`;
   }
-  return { primary: original, secondary: null, display: original };
-}
-
-function NewValueIndicator({
-  isVisible,
-  value,
-  textSize,
-}: {
-  isVisible: boolean;
-  value: string | null;
-  textSize: 'text-base' | 'text-sm';
-}) {
-  return (
-    <>
-      <span className={cn('text-muted-foreground shrink-0', !isVisible && 'invisible')}>→</span>
-      <span
-        className={cn(
-          'text-primary min-w-0 truncate font-medium',
-          textSize,
-          !isVisible && 'invisible',
-        )}
-      >
-        {value ?? ' '}
-      </span>
-    </>
-  );
+  return original;
 }
 
 export default function ReportSongModal({
@@ -88,9 +53,6 @@ export default function ReportSongModal({
   num_ky,
   handleClose,
 }: ReportSongModalProps) {
-  const titleParts = splitDisplay(title_ko, title);
-  const artistParts = splitDisplay(artist_ko, artist);
-
   const [category, setCategory] = useState<ReportCategory | null>(null);
   const [suggestedValue, setSuggestedValue] = useState('');
   const [isNoData, setIsNoData] = useState(false);
@@ -146,17 +108,15 @@ export default function ReportSongModal({
     );
   };
 
-  const activeField = category ? CATEGORY_TO_FIELD[category] : null;
-  const newValue = isNoData ? NO_DATA_LABEL : suggestedValue.trim() || null;
-
-  const isFieldActive = (field: CardField) => activeField === field && newValue !== null;
+  const activeField = category ? REPORT_CATEGORY_TO_FIELD[category] : null;
+  const newValue = isNoData ? REPORT_NO_DATA_LABEL : suggestedValue.trim() || null;
 
   return (
     <div className="flex flex-col gap-4 sm:max-w-md">
       <DialogHeader>
         <DialogTitle>오류 신고</DialogTitle>
         <DialogDescription className="sr-only">
-          {titleParts.display} - {artistParts.display} 곡에 대한 오류 신고
+          {getDisplay(title_ko, title)} - {getDisplay(artist_ko, artist)} 곡에 대한 오류 신고
         </DialogDescription>
       </DialogHeader>
 
@@ -179,90 +139,16 @@ export default function ReportSongModal({
           ))}
         </RadioGroup>
 
-        <div className="flex flex-col gap-3 rounded-md border p-4">
-          <div className="flex flex-col gap-1">
-            <div
-              className={cn(
-                'rounded-sm px-2 py-1 transition-colors',
-                activeField === 'title' && 'bg-primary/10',
-              )}
-            >
-              <div className="flex min-w-0 flex-col gap-0.5">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="min-w-0 truncate text-base font-medium">
-                    {titleParts.primary}
-                  </span>
-                  <NewValueIndicator
-                    isVisible={isFieldActive('title')}
-                    value={newValue}
-                    textSize="text-base"
-                  />
-                </div>
-                {titleParts.secondary && (
-                  <span className="text-muted-foreground truncate text-xs">
-                    {titleParts.secondary}
-                  </span>
-                )}
-              </div>
-            </div>
-
-            <div
-              className={cn(
-                'rounded-sm px-2 py-1 transition-colors',
-                activeField === 'artist' && 'bg-primary/10',
-              )}
-            >
-              <div className="flex min-w-0 flex-col gap-0.5">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="text-muted-foreground min-w-0 truncate text-sm">
-                    {artistParts.primary}
-                  </span>
-                  <NewValueIndicator
-                    isVisible={isFieldActive('artist')}
-                    value={newValue}
-                    textSize="text-sm"
-                  />
-                </div>
-                {artistParts.secondary && (
-                  <span className="text-muted-foreground/70 truncate text-xs">
-                    {artistParts.secondary}
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="flex gap-2 border-t pt-2">
-            <div
-              className={cn(
-                'flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 transition-colors',
-                activeField === 'num_tj' && 'bg-primary/10',
-              )}
-            >
-              <span className="text-brand-tj shrink-0 text-xs font-bold">TJ</span>
-              <span className="min-w-0 truncate text-sm font-medium">{num_tj || '-'}</span>
-              <NewValueIndicator
-                isVisible={isFieldActive('num_tj')}
-                value={newValue}
-                textSize="text-sm"
-              />
-            </div>
-            <div
-              className={cn(
-                'flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 transition-colors',
-                activeField === 'num_ky' && 'bg-primary/10',
-              )}
-            >
-              <span className="text-brand-ky shrink-0 text-xs font-bold">금영</span>
-              <span className="min-w-0 truncate text-sm font-medium">{num_ky || '-'}</span>
-              <NewValueIndicator
-                isVisible={isFieldActive('num_ky')}
-                value={newValue}
-                textSize="text-sm"
-              />
-            </div>
-          </div>
-        </div>
+        <ReportFieldCard
+          title={title}
+          artist={artist}
+          title_ko={title_ko}
+          artist_ko={artist_ko}
+          num_tj={num_tj}
+          num_ky={num_ky}
+          activeField={activeField}
+          newValue={newValue}
+        />
 
         <div className="flex flex-col gap-2">
           <Label htmlFor="report-suggested-value">올바른 정보</Label>
@@ -273,7 +159,7 @@ export default function ReportSongModal({
                 ? '5자리 숫자로 입력해주세요.'
                 : '어떤 내용으로 바뀌어야 하는지 적어주세요.'
             }
-            value={isNoData ? NO_DATA_LABEL : suggestedValue}
+            value={isNoData ? REPORT_NO_DATA_LABEL : suggestedValue}
             onChange={e => handleSuggestedValueChange(e.target.value)}
             maxLength={inputMaxLength}
             inputMode={isNumberMode ? 'numeric' : undefined}

--- a/apps/web/src/lib/api/reportSong.ts
+++ b/apps/web/src/lib/api/reportSong.ts
@@ -1,5 +1,5 @@
 import { ApiResponse } from '@/types/apiRoute';
-import { ReportCategory } from '@/types/report';
+import { MyReport, ReportCategory } from '@/types/report';
 
 import { instance } from './client';
 
@@ -11,5 +11,15 @@ export interface PostSongReportBody {
 
 export async function postSongReport(body: PostSongReportBody) {
   const response = await instance.post<ApiResponse<void>>('/songs/report', body);
+  return response.data;
+}
+
+export async function getMyReports() {
+  const response = await instance.get<ApiResponse<MyReport[]>>('/songs/report');
+  return response.data;
+}
+
+export async function deleteMyReport(body: { reportId: string }) {
+  const response = await instance.delete<ApiResponse<void>>('/songs/report', { data: body });
   return response.data;
 }

--- a/apps/web/src/queries/reportSongQuery.ts
+++ b/apps/web/src/queries/reportSongQuery.ts
@@ -1,8 +1,14 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { toast } from 'sonner';
 
-import { PostSongReportBody, postSongReport } from '@/lib/api/reportSong';
+import {
+  PostSongReportBody,
+  deleteMyReport,
+  getMyReports,
+  postSongReport,
+} from '@/lib/api/reportSong';
+import { MyReport } from '@/types/report';
 
 export const useReportSongMutation = () => {
   return useMutation({
@@ -18,6 +24,49 @@ export const useReportSongMutation = () => {
       }
       const message = error instanceof Error ? error.message : '신고 접수 실패';
       toast.error(message);
+    },
+  });
+};
+
+export const useMyReportsQuery = (isAuthenticated: boolean) => {
+  return useQuery({
+    queryKey: ['myReports'],
+    queryFn: async () => {
+      const response = await getMyReports();
+      if (!response.success) {
+        return [];
+      }
+      return response.data || [];
+    },
+    enabled: isAuthenticated,
+  });
+};
+
+export const useDeleteMyReportMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (reportId: string) => deleteMyReport({ reportId }),
+
+    onMutate: async (reportId: string) => {
+      await queryClient.cancelQueries({ queryKey: ['myReports'] });
+      const prev = queryClient.getQueryData<MyReport[]>(['myReports']);
+      queryClient.setQueryData<MyReport[]>(['myReports'], old =>
+        (old ?? []).filter(report => report.id !== reportId),
+      );
+      return { prev };
+    },
+    onSuccess: () => {
+      toast.success('신고 내역이 삭제되었습니다.');
+    },
+    onError: (error, _reportId, context) => {
+      console.error('Delete report error:', error);
+      queryClient.setQueryData(['myReports'], context?.prev);
+      const message = error instanceof Error ? error.message : '신고 내역 삭제 실패';
+      toast.error(message);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['myReports'] });
     },
   });
 };

--- a/apps/web/src/types/report.ts
+++ b/apps/web/src/types/report.ts
@@ -14,6 +14,17 @@ export const REPORT_CATEGORY_LABEL: Record<ReportCategory, string> = {
   num_ky: '금영 번호',
 };
 
+export type ReportCardField = 'title' | 'artist' | 'num_tj' | 'num_ky';
+
+export const REPORT_CATEGORY_TO_FIELD: Record<ReportCategory, ReportCardField> = {
+  title_translation: 'title',
+  artist_translation: 'artist',
+  num_tj: 'num_tj',
+  num_ky: 'num_ky',
+};
+
+export const REPORT_NO_DATA_LABEL = '데이터 없음';
+
 export type ReportStatus = 'pending' | 'applied' | 'rejected';
 
 export const REPORT_STATUSES: ReportStatus[] = ['pending', 'applied', 'rejected'];
@@ -23,3 +34,18 @@ export const REPORT_STATUS_LABEL: Record<ReportStatus, string> = {
   applied: '반영됨',
   rejected: '거절됨',
 };
+
+export interface MyReport {
+  id: string;
+  song_id: string;
+  category: ReportCategory;
+  suggested_value: string | null;
+  status: ReportStatus;
+  created_at: string;
+  title: string;
+  artist: string;
+  title_ko?: string;
+  artist_ko?: string;
+  num_tj: string;
+  num_ky: string;
+}


### PR DESCRIPTION
## Summary

Closes #219

- `/info/reports` 페이지 신규 — 자신이 등록한 곡 오류 신고 내역을 확인하고 본인이 직접 삭제 가능
- info 메뉴(`/info`)에 진입 카드 추가 (`Flag` 아이콘 → `/info/reports`)
- `GET / DELETE /api/songs/report` 추가
  - GET: `song_reports` JOIN `songs` (title/artist + 번역본 + TJ/금영 번호), 본인 데이터만 최신순
  - DELETE: `id + user_id` 매치 + `count: 'exact'`로 0건이면 404 반환 (RLS와 별개로 서버에서도 본인 검증)
- 신고 카드 레이아웃을 `ReportFieldCard` 공통 컴포넌트로 추출 — `ReportSongModal`과 `ReportItem`이 같은 카드 + 화살표(→) 표시 패턴을 공유
- 카테고리/상태 배지화 (TJ/금영은 brand-tj/brand-ky 톤, 제목/가수는 sky/pink, 상태는 amber/emerald/red)

## Test plan

- [ ] `/info` 진입 → '내 신고 내역' 카드 클릭 → `/info/reports` 이동
- [ ] 비로그인 상태 직접 진입 → `/login?alert=login` 리다이렉트 (auth.tsx의 `ALLOW_PATHS` 미포함)
- [ ] 신고 내역 리스트가 최신순으로 표시되고, 카테고리에 해당하는 필드(`title`/`artist`/`num_tj`/`num_ky`)에 화살표(→ suggested_value)가 하이라이트되는지
- [ ] 상태(`pending`/`applied`/`rejected`) · 카테고리 배지가 색상별로 구분되는지
- [ ] 휴지통 클릭 → 확인 모달 → 삭제 시 optimistic update로 즉시 사라지고, 새로고침해도 유지
- [ ] 삭제 후 동일 곡/카테고리 재신고 가능 (unique violation 발생 X)
- [ ] 다크 모드에서 배지 가독성 확인

## Notes

- `song_reports` RLS 정책이 본인 데이터만 select/delete 허용하는지 운영 환경 점검 필요. 서버 사이드에서 `user_id` 매치를 강제하지만 RLS도 이중 방어로 활성화 권장.
- 테스트 스위트가 프로젝트에 미설정 → `/red` 단계 생략, 정적 검증(tsc + lint + build)으로 대체.

🤖 Generated with [Claude Code](https://claude.com/claude-code)