### PR TITLE
Fix : Service Worker(/sw.js) Cache-Control 헤더 추가 (#239)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,7 +3,19 @@ import withSerwistInit from '@serwist/next';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/sw.js',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 const withBundle = withBundleAnalyzer({


### PR DESCRIPTION
## 📌 PR 제목

### [Fix] : Service Worker(/sw.js) Cache-Control 헤더 추가

## 📌 변경 사항

- `apps/web/next.config.ts`에 `async headers()` 추가
- `/sw.js` 응답에 `Cache-Control: public, max-age=0, must-revalidate` 적용
- 결과적으로 브라우저가 매 페이지 로드마다 SW 갱신 여부를 확인하게 되어, main 머지 후 구 Service Worker의 precache 매니페스트가 최대 24시간 살아남던 위험을 제거

## 💬 추가 참고 사항

- close #239
- 본 PR은 캐시 헤더 한 건만 추가한다. 후속 작업 후보는 별도 이슈로 분리한다.
  - `/api/version` 응답에 `Cache-Control: no-store` 적용
  - `PWARegister`에 SW `updatefound` 감지 + 새로고침 안내 토스트 추가
  - `/data/changelog.json`의 SW precache 제외 검토
- 검증
  - `pnpm --filter web build` 성공 (타입 체크 포함, 신규 에러 0)
  - `pnpm --filter web lint` 통과 (신규 warning 0, 기존 warning만 존재)
  - `pnpm --filter web format` 통과 (포맷 변경 없음)
  - 테스트 스위트는 프로젝트 미구성
