### PR TITLE
[Feat] : 검색 페이지 한글 제목/가수 검색 및 번호 검색 필터 추가 (#244)

### DIFF
--- a/apps/web/public/sitemap-0.xml
+++ b/apps/web/public/sitemap-0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.singcode.kr/manifest.webmanifest</loc><lastmod>2026-05-19T13:17:55.218Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.singcode.kr</loc><lastmod>2026-05-19T13:17:55.220Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.singcode.kr/patch-notes</loc><lastmod>2026-05-19T13:17:55.220Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr/manifest.webmanifest</loc><lastmod>2026-05-25T11:26:49.726Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr/patch-notes</loc><lastmod>2026-05-25T11:26:49.727Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.singcode.kr</loc><lastmod>2026-05-25T11:26:49.727Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/web/src/app/api/search/log/route.ts
+++ b/apps/web/src/app/api/search/log/route.ts
@@ -1,3 +1,4 @@
+import { subDays } from 'date-fns';
 import { NextResponse } from 'next/server';
 
 import createClient from '@/lib/supabase/server';
@@ -11,7 +12,13 @@ interface SearchLogCount {
 export async function GET(): Promise<NextResponse<ApiResponse<SearchLogCount[]>>> {
   try {
     const supabase = await createClient();
-    const { data, error } = await supabase.from('search_logs').select('text');
+
+    // 최근 15일간의 검색 로그만 집계
+    const fifteenDaysAgo = subDays(new Date(), 15).toISOString();
+    const { data, error } = await supabase
+      .from('search_logs')
+      .select('text')
+      .gte('created_at', fifteenDaysAgo);
 
     if (error) throw error;
 

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -24,7 +24,18 @@ interface DBSong extends Song {
 
 function applyExactFilter(baseQuery: any, type: string, searchText: string) {
   if (type === 'all') {
-    return baseQuery.or(`title.ilike.${searchText},artist.ilike.${searchText}`);
+    return baseQuery.or(
+      `title.ilike.${searchText},title_ko.ilike.${searchText},artist.ilike.${searchText},artist_ko.ilike.${searchText}`,
+    );
+  }
+  if (type === 'title') {
+    return baseQuery.or(`title.ilike.${searchText},title_ko.ilike.${searchText}`);
+  }
+  if (type === 'artist') {
+    return baseQuery.or(`artist.ilike.${searchText},artist_ko.ilike.${searchText}`);
+  }
+  if (type === 'number') {
+    return baseQuery.or(`num_tj.eq.${searchText},num_ky.eq.${searchText}`);
   }
   return baseQuery.ilike(type, searchText);
 }
@@ -32,9 +43,25 @@ function applyExactFilter(baseQuery: any, type: string, searchText: string) {
 function applyPartialFilter(baseQuery: any, type: string, searchText: string) {
   if (type === 'all') {
     return baseQuery
-      .or(`title.ilike.%${searchText}%,artist.ilike.%${searchText}%`)
+      .or(
+        `title.ilike.%${searchText}%,title_ko.ilike.%${searchText}%,artist.ilike.%${searchText}%,artist_ko.ilike.%${searchText}%`,
+      )
       .not('title', 'ilike', searchText)
-      .not('artist', 'ilike', searchText);
+      .not('title_ko', 'ilike', searchText)
+      .not('artist', 'ilike', searchText)
+      .not('artist_ko', 'ilike', searchText);
+  }
+  if (type === 'title') {
+    return baseQuery
+      .or(`title.ilike.%${searchText}%,title_ko.ilike.%${searchText}%`)
+      .not('title', 'ilike', searchText)
+      .not('title_ko', 'ilike', searchText);
+  }
+  if (type === 'artist') {
+    return baseQuery
+      .or(`artist.ilike.%${searchText}%,artist_ko.ilike.%${searchText}%`)
+      .not('artist', 'ilike', searchText)
+      .not('artist_ko', 'ilike', searchText);
   }
   return baseQuery.ilike(type, `%${searchText}%`).not(type, 'ilike', searchText);
 }
@@ -49,6 +76,26 @@ async function executeSearchQueries(
   to: number,
 ): Promise<{ data: DBSong[]; hasNext: boolean } | { error: string }> {
   const size = to - from + 1;
+
+  // 번호 검색은 정확 매칭만 지원 (부분 일치 단계 스킵)
+  if (type === 'number') {
+    const exactCountResult = await applyExactFilter(
+      supabase.from('songs').select(selectClause, { count: 'exact', head: true }),
+      type,
+      query,
+    );
+    if (exactCountResult.error) return { error: exactCountResult.error.message };
+    const exactTotal = exactCountResult.count ?? 0;
+
+    const exactQuery = applyExactFilter(supabase.from('songs').select(selectClause), type, query);
+    const { data, error } = await exactQuery.order(order).range(from, to);
+    if (error) return { error: error.message };
+
+    return {
+      data: (data as DBSong[]) ?? [],
+      hasNext: exactTotal > to + 1,
+    };
+  }
 
   // 1. 정확 일치 / 부분 일치 각각의 총 개수를 병렬로 조회
   const exactCountQuery = applyExactFilter(
@@ -134,7 +181,7 @@ export async function GET(request: Request): Promise<NextResponse<ApiResponse<Se
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q');
     const type = searchParams.get('type') || 'title';
-    const order = type === 'all' ? 'title' : type;
+    const order = type === 'all' ? 'title' : type === 'number' ? 'num_tj' : type;
     const authenticated = searchParams.get('authenticated') === 'true';
 
     const page = parseInt(searchParams.get('page') || '0', 10);

--- a/apps/web/src/app/api/songs/like/route.ts
+++ b/apps/web/src/app/api/songs/like/route.ts
@@ -36,6 +36,8 @@ export async function GET(): Promise<NextResponse<ApiResponse<PersonalSong[]>>> 
       created_at: item.created_at,
       title: item.songs.title,
       artist: item.songs.artist,
+      title_ko: item.songs.title_ko,
+      artist_ko: item.songs.artist_ko,
       num_tj: item.songs.num_tj,
       num_ky: item.songs.num_ky,
     }));

--- a/apps/web/src/app/api/songs/save/route.ts
+++ b/apps/web/src/app/api/songs/save/route.ts
@@ -38,6 +38,8 @@ export async function GET(): Promise<NextResponse<ApiResponse<SaveSong[]>>> {
       updated_at: item.updated_at,
       title: item.songs.title,
       artist: item.songs.artist,
+      title_ko: item.songs.title_ko,
+      artist_ko: item.songs.artist_ko,
       num_tj: item.songs.num_tj,
       num_ky: item.songs.num_ky,
     }));

--- a/apps/web/src/app/info/like/SongItem.tsx
+++ b/apps/web/src/app/info/like/SongItem.tsx
@@ -22,7 +22,13 @@ export default function SongItem({
       />
       <div className="min-w-0 flex-1">
         <MarqueeText className="text-sm font-medium">{song.title}</MarqueeText>
+        {song.title_ko && song.title_ko !== song.title && (
+          <MarqueeText className="text-muted-foreground text-xs">{song.title_ko}</MarqueeText>
+        )}
         <MarqueeText className="text-muted-foreground text-xs">{song.artist}</MarqueeText>
+        {song.artist_ko && song.artist_ko !== song.artist && (
+          <MarqueeText className="text-muted-foreground/70 text-xs">{song.artist_ko}</MarqueeText>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/info/save/FolderCard.tsx
+++ b/apps/web/src/app/info/save/FolderCard.tsx
@@ -111,7 +111,13 @@ export default function FolderCard({
                         <Music className="text-muted-foreground h-4 w-4 shrink-0" />
                         <div>
                           <p className="text-sm font-medium">{song.title}</p>
+                          {song.title_ko && song.title_ko !== song.title && (
+                            <p className="text-muted-foreground text-xs">{song.title_ko}</p>
+                          )}
                           <p className="text-muted-foreground text-xs">{song.artist}</p>
+                          {song.artist_ko && song.artist_ko !== song.artist && (
+                            <p className="text-muted-foreground/70 text-xs">{song.artist_ko}</p>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/apps/web/src/app/search/AddFolderModal.tsx
+++ b/apps/web/src/app/search/AddFolderModal.tsx
@@ -46,7 +46,7 @@ export default function AddFolderModal({
   const [folderName, setFolderName] = useState<string>('');
   const [isExistingPlaylist, setIsExistingPlaylist] = useState(false);
 
-  const { id: songId, title, artist } = song;
+  const { id: songId, title, artist, title_ko, artist_ko } = song;
 
   const LOGIC_TEXT = modalType === 'POST' ? '저장' : '수정';
 
@@ -114,7 +114,13 @@ export default function AddFolderModal({
         {/* 곡 정보 */}
         <div className="bg-muted mb-4 rounded-md p-3">
           <MarqueeText className="text-base font-medium">{title}</MarqueeText>
+          {title_ko && title_ko !== title && (
+            <MarqueeText className="text-muted-foreground text-xs">{title_ko}</MarqueeText>
+          )}
           <MarqueeText className="text-muted-foreground text-sm">{artist}</MarqueeText>
+          {artist_ko && artist_ko !== artist && (
+            <MarqueeText className="text-muted-foreground/70 text-xs">{artist_ko}</MarqueeText>
+          )}
         </div>
 
         <div className="w-full space-y-4 py-2">

--- a/apps/web/src/app/search/HomePage.tsx
+++ b/apps/web/src/app/search/HomePage.tsx
@@ -120,6 +120,8 @@ export default function SearchPage() {
         return '노래 제목 검색';
       case 'artist':
         return '가수 이름 검색';
+      case 'number':
+        return '노래방 번호 검색 (TJ/KY)';
       default:
         return '전체 키워드 검색';
     }
@@ -169,12 +171,13 @@ export default function SearchPage() {
         </div>
 
         <Tabs defaultValue="all" value={searchType} onValueChange={handleSearchTypeChange}>
-          <TabsList className="dark:bg-muted/50 grid w-full grid-cols-3 dark:border">
+          <TabsList className="dark:bg-muted/50 grid w-full grid-cols-4 dark:border">
             {(
               [
                 ['all', '전체'],
                 ['title', '제목'],
                 ['artist', '가수'],
+                ['number', '번호'],
               ] as const
             ).map(([value, label]) => (
               <TabsTrigger

--- a/apps/web/src/app/search/SearchResultCard.tsx
+++ b/apps/web/src/app/search/SearchResultCard.tsx
@@ -143,6 +143,8 @@ export default function SearchResultCard({
                   songId={id}
                   title={title}
                   artist={artist}
+                  title_ko={title_ko}
+                  artist_ko={artist_ko}
                   thumb={thumb || 0}
                   handleClose={() => setOpen(false)}
                 />

--- a/apps/web/src/app/search/SearchResultCard.tsx
+++ b/apps/web/src/app/search/SearchResultCard.tsx
@@ -261,7 +261,7 @@ export default function SearchResultCard({
         </AnimatePresence>
 
         <Dialog open={promotionOpen} onOpenChange={setPromotionOpen}>
-          <DialogContent>
+          <DialogContent className="h-[600px] max-h-[calc(100dvh-2rem)] overflow-y-auto">
             <SongPromotionModal
               songId={id}
               title={title}

--- a/apps/web/src/app/tosing/ModalSongItem.tsx
+++ b/apps/web/src/app/tosing/ModalSongItem.tsx
@@ -28,7 +28,13 @@ export default function ModalSongItem({
       />
       <div className="min-w-0 flex-1">
         <MarqueeText className="text-sm font-medium">{song.title}</MarqueeText>
+        {song.title_ko && song.title_ko !== song.title && (
+          <MarqueeText className="text-muted-foreground text-xs">{song.title_ko}</MarqueeText>
+        )}
         <MarqueeText className="text-muted-foreground text-xs">{song.artist}</MarqueeText>
+        {song.artist_ko && song.artist_ko !== song.artist && (
+          <MarqueeText className="text-muted-foreground/70 text-xs">{song.artist_ko}</MarqueeText>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/PromotionBanner.tsx
+++ b/apps/web/src/components/PromotionBanner.tsx
@@ -86,7 +86,7 @@ export default function PromotionBanner() {
             transition={{ duration: 0.25, ease: 'easeInOut' }}
             className="overflow-hidden"
           >
-            <div className="h-24 overflow-hidden">
+            <div className="h-32 overflow-hidden">
               <AnimatePresence mode="wait">
                 <motion.div
                   key={current.id}
@@ -97,20 +97,20 @@ export default function PromotionBanner() {
                   className="flex flex-col gap-2"
                 >
                   <div className="flex flex-col gap-0.5">
-                    <div className="flex items-baseline gap-1.5 truncate">
+                    <div className="flex flex-col">
                       <span className="truncate text-sm font-semibold">{current.title}</span>
                       {hasKoTitle && (
-                        <span className="text-muted-foreground shrink-0 truncate text-xs">
+                        <span className="text-muted-foreground truncate text-xs">
                           {current.title_ko}
                         </span>
                       )}
                     </div>
-                    <div className="flex items-baseline gap-1.5 truncate">
+                    <div className="flex flex-col">
                       <span className="text-muted-foreground truncate text-sm">
                         {current.artist}
                       </span>
                       {hasKoArtist && (
-                        <span className="text-muted-foreground/70 shrink-0 truncate text-xs">
+                        <span className="text-muted-foreground/70 truncate text-xs">
                           {current.artist_ko}
                         </span>
                       )}

--- a/apps/web/src/components/RankingItem.tsx
+++ b/apps/web/src/components/RankingItem.tsx
@@ -14,6 +14,8 @@ interface RankingItemProps {
   rank: number;
   title: string;
   artist: string;
+  title_ko?: string;
+  artist_ko?: string;
   num_tj: string;
   num_ky: string;
   value: number;
@@ -25,6 +27,8 @@ export default function RankingItem({
   rank,
   title,
   artist,
+  title_ko,
+  artist_ko,
   num_tj,
   num_ky,
   value,
@@ -68,7 +72,13 @@ export default function RankingItem({
       <div className="flex w-full justify-between gap-2">
         <div className="w-[100px] shrink-0">
           <MarqueeText className="text-sm font-medium">{title}</MarqueeText>
+          {title_ko && title_ko !== title && (
+            <MarqueeText className="text-muted-foreground text-xs">{title_ko}</MarqueeText>
+          )}
           <MarqueeText className="text-muted-foreground text-xs">{artist}</MarqueeText>
+          {artist_ko && artist_ko !== artist && (
+            <MarqueeText className="text-muted-foreground/70 text-xs">{artist_ko}</MarqueeText>
+          )}
         </div>
 
         <div>
@@ -82,7 +92,7 @@ export default function RankingItem({
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex gap-2">
           <Dialog open={open} onOpenChange={setOpen}>
             <Button
               variant="ghost"
@@ -102,6 +112,8 @@ export default function RankingItem({
                 songId={id}
                 title={title}
                 artist={artist}
+                title_ko={title_ko}
+                artist_ko={artist_ko}
                 thumb={value}
                 handleClose={() => setOpen(false)}
               />

--- a/apps/web/src/components/SongPromotionModal.tsx
+++ b/apps/web/src/components/SongPromotionModal.tsx
@@ -139,9 +139,7 @@ export default function SongPromotionModal({
     <div className="flex flex-col gap-4 sm:max-w-md">
       <DialogHeader>
         <DialogTitle>곡 홍보하기</DialogTitle>
-        <DialogDescription>
-          하루 50P를 소모해 검색 페이지 전광판에 곡을 홍보하세요.
-        </DialogDescription>
+        <DialogDescription>하루 단위로 전광판에 곡을 홍보할 수 있어요.</DialogDescription>
       </DialogHeader>
 
       <div className="text-muted-foreground flex flex-col gap-0.5 rounded-md border p-3 text-sm">

--- a/apps/web/src/components/ThumbUpModal.tsx
+++ b/apps/web/src/components/ThumbUpModal.tsx
@@ -20,6 +20,8 @@ interface ThumbUpModalProps {
   songId: string;
   title: string;
   artist: string;
+  title_ko?: string;
+  artist_ko?: string;
   thumb: number;
   handleClose: () => void;
 }
@@ -28,6 +30,8 @@ export default function ThumbUpModal({
   songId,
   title,
   artist,
+  title_ko,
+  artist_ko,
   thumb,
   handleClose,
 }: ThumbUpModalProps) {
@@ -118,7 +122,13 @@ export default function ThumbUpModal({
           <FallingIcons count={value[0]} />
           <div className="absolute top-0 left-0 flex h-full w-full flex-col items-center justify-center px-4 text-center opacity-50">
             <div className="text-lg font-bold">{title}</div>
+            {title_ko && title_ko !== title && (
+              <div className="text-muted-foreground text-sm">{title_ko}</div>
+            )}
             <div className="text-muted-foreground text-sm">{artist}</div>
+            {artist_ko && artist_ko !== artist && (
+              <div className="text-muted-foreground/70 text-xs">{artist_ko}</div>
+            )}
           </div>
         </div>
 

--- a/apps/web/src/hooks/useSaveSongModal.ts
+++ b/apps/web/src/hooks/useSaveSongModal.ts
@@ -6,10 +6,9 @@ import { useSaveMutation } from '@/queries/searchSongQuery';
 import useAuthStore from '@/stores/useAuthStore';
 import useFooterAnimateStore from '@/stores/useFooterAnimateStore';
 import { Method } from '@/types/common';
-import { SearchSong } from '@/types/song';
+import { SearchSong, SearchType } from '@/types/song';
 
 type SaveModalType = '' | 'POST' | 'PATCH';
-type SearchType = 'all' | 'title' | 'artist';
 
 export default function useSaveSongModal(query: string, queryType: SearchType) {
   const { isAuthenticated } = useAuthStore();

--- a/apps/web/src/hooks/useSearchSong.ts
+++ b/apps/web/src/hooks/useSearchSong.ts
@@ -12,10 +12,8 @@ import useFooterAnimateStore from '@/stores/useFooterAnimateStore';
 import useGuestToSingStore from '@/stores/useGuestToSingStore';
 import useSearchHistoryStore from '@/stores/useSearchHistoryStore';
 import { Method } from '@/types/common';
-import { Song } from '@/types/song';
+import { SearchType, Song } from '@/types/song';
 import { getAutoCompleteSuggestions } from '@/utils/getArtistAlias';
-
-type SearchType = 'all' | 'title' | 'artist';
 
 export default function useSearchSong() {
   const { isAuthenticated } = useAuthStore();

--- a/apps/web/src/types/song.ts
+++ b/apps/web/src/types/song.ts
@@ -1,3 +1,5 @@
+export type SearchType = 'all' | 'title' | 'artist' | 'number';
+
 export interface Song {
   id: string;
   title: string;


### PR DESCRIPTION
## 📌 PR 제목

### [Feat] : 검색 페이지 한글 제목/가수 검색 및 번호 검색 필터 추가

## 📌 변경 사항

- **검색 기능**: 한글 제목(`title_ko`)/가수(`artist_ko`) 컬럼을 검색 대상에 포함, 노래방 번호(TJ/KY) 검색 필터 추가 (번호는 정확 매칭만 지원)
- **검색 UI**: 검색 탭에 `번호` 옵션 추가(`SearchType`에 `number` 추가 및 타입 공통화)
- **한글 표시 확대**: 즐겨찾기 목록·재생목록·인기차트·추천 모달·저장 모달 등 곡 렌더링 전반에 한글 제목/가수 표시 추가
- **API 보완(fix)**: 즐겨찾기·저장 곡 API 응답에서 한글 필드(`title_ko`/`artist_ko`) 누락 보완
- **홍보 모달(fix)**: 모바일에서 홍보 모달 높이가 잘리던 문제 수정(고정 높이 + 내부 스크롤)
- **전광판(refactor)**: 한글 번역을 원문 우측이 아닌 아래로 세로 배치, 높이 조정
- **기타(chore/feat)**: 검색 로그 집계를 최근 15일로 제한, 홍보 모달 안내 문구 수정 및 sitemap 재생성

## 💬 추가 참고 사항

- 검증: `tsc --noEmit` 통과, `pnpm lint` 에러 없음 (테스트 스위트 없음)
- `search_logs` 테이블의 타임스탬프 컬럼명을 `created_at`으로 가정함
- close #244
