### PR TITLE
[Feat] : 검색 단어 단위 AND 매칭 및 부분 일치 NULL 누락 버그 수정 (#254)

### DIFF
--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -33,9 +33,15 @@ function getSearchColumns(type: string): string[] {
   return SEARCH_COLUMNS[type] ?? [type];
 }
 
-// 공백 기준 토큰 분리 (빈 토큰 제거)
+// 공백 기준 토큰 분리 (빈 토큰 제거).
+// PostgREST .or() 필터에서 값 구분자/그룹 문자로 쓰이는 예약 문자(, ( ) ")가 값에 포함되면
+// 조건이 분리되거나 문법이 깨지므로, 토큰화 전에 공백으로 치환해 안전하게 만든다.
 function tokenizeQuery(searchText: string): string[] {
-  return searchText.trim().split(/\s+/).filter(Boolean);
+  return searchText
+    .replace(/[,()"]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
 }
 
 // 토큰을 %로 이어 붙인 전체 구 패턴 (띄어쓰기 차이를 무시한 완전 일치용)
@@ -116,6 +122,11 @@ async function executeSearchQueries(
       data: (data as DBSong[]) ?? [],
       hasNext: exactTotal > to + 1,
     };
+  }
+
+  // 공백/예약 문자만 입력돼 유효 토큰이 없으면 빈 패턴 필터가 생성되므로 빈 결과로 방어한다.
+  if (tokenizeQuery(query).length === 0) {
+    return { data: [], hasNext: false };
   }
 
   // 1. 정확 일치 / 부분 일치 각각의 총 개수를 병렬로 조회
@@ -200,7 +211,8 @@ export async function GET(request: Request): Promise<NextResponse<ApiResponse<Se
   // API KEY 노출을 막기 위해 미들웨어 역할을 할 API ROUTE 활용
   try {
     const { searchParams } = new URL(request.url);
-    const query = searchParams.get('q');
+    // 공백-only 입력은 토큰이 비어 빈 패턴 필터를 만들므로 trim 후 빈 값은 400으로 거른다.
+    const query = searchParams.get('q')?.trim() ?? '';
     const type = searchParams.get('type') || 'title';
     const order = type === 'all' ? 'title' : type === 'number' ? 'num_tj' : type;
     const authenticated = searchParams.get('authenticated') === 'true';

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -22,48 +22,69 @@ interface DBSong extends Song {
   }[];
 }
 
+// 검색 타입별 대상 컬럼
+const SEARCH_COLUMNS: Record<string, string[]> = {
+  all: ['title', 'title_ko', 'artist', 'artist_ko'],
+  title: ['title', 'title_ko'],
+  artist: ['artist', 'artist_ko'],
+};
+
+function getSearchColumns(type: string): string[] {
+  return SEARCH_COLUMNS[type] ?? [type];
+}
+
+// 공백 기준 토큰 분리 (빈 토큰 제거)
+function tokenizeQuery(searchText: string): string[] {
+  return searchText.trim().split(/\s+/).filter(Boolean);
+}
+
+// 토큰을 %로 이어 붙인 전체 구 패턴 (띄어쓰기 차이를 무시한 완전 일치용)
+// 예: ['사건의', '지평선'] -> '사건의%지평선' → '사건의지평선', '사건의 지평선' 모두 매칭
+function buildPhrasePattern(tokens: string[]): string {
+  return tokens.join('%');
+}
+
+// 여러 컬럼에 같은 ilike 패턴을 적용한 OR 그룹 조건 문자열 (PostgREST .or() 인자)
+// 예: (['title','title_ko'], '%로드%') -> 'title.ilike.%로드%,title_ko.ilike.%로드%'
+function buildColumnOrGroup(columns: string[], pattern: string): string {
+  return columns.map(column => `${column}.ilike.${pattern}`).join(',');
+}
+
+// 정확 일치: 전체 구가 한 컬럼과 일치 (랭킹 상위). 띄어쓰기 차이는 무시한다.
 function applyExactFilter(baseQuery: any, type: string, searchText: string) {
-  if (type === 'all') {
-    return baseQuery.or(
-      `title.ilike.${searchText},title_ko.ilike.${searchText},artist.ilike.${searchText},artist_ko.ilike.${searchText}`,
-    );
-  }
-  if (type === 'title') {
-    return baseQuery.or(`title.ilike.${searchText},title_ko.ilike.${searchText}`);
-  }
-  if (type === 'artist') {
-    return baseQuery.or(`artist.ilike.${searchText},artist_ko.ilike.${searchText}`);
-  }
   if (type === 'number') {
     return baseQuery.or(`num_tj.eq.${searchText},num_ky.eq.${searchText}`);
   }
-  return baseQuery.ilike(type, searchText);
+
+  const phrase = buildPhrasePattern(tokenizeQuery(searchText));
+  const columns = getSearchColumns(type);
+
+  return baseQuery.or(buildColumnOrGroup(columns, phrase));
 }
 
+// 부분 일치: 입력한 모든 토큰이 (순서 무관) 포함돼야 매칭(AND) + 정확 일치 결과는 제외.
 function applyPartialFilter(baseQuery: any, type: string, searchText: string) {
-  if (type === 'all') {
-    return baseQuery
-      .or(
-        `title.ilike.%${searchText}%,title_ko.ilike.%${searchText}%,artist.ilike.%${searchText}%,artist_ko.ilike.%${searchText}%`,
-      )
-      .not('title', 'ilike', searchText)
-      .not('title_ko', 'ilike', searchText)
-      .not('artist', 'ilike', searchText)
-      .not('artist_ko', 'ilike', searchText);
+  const tokens = tokenizeQuery(searchText);
+  const phrase = buildPhrasePattern(tokens);
+  const columns = getSearchColumns(type);
+
+  // 토큰 AND 조건: 각 토큰의 "컬럼 OR 그룹"을 .or() 체이닝으로 AND 결합한다.
+  // (PostgREST에서 .or() 체이닝은 서로 AND로 묶인다)
+  // 예: '바톤 로드' → (바톤 in any col) AND (로드 in any col)
+  //     → '오버로드'(로드만), '로드넘버원'(로드만)은 바톤이 없어 제외된다.
+  let query = baseQuery;
+  for (const token of tokens) {
+    query = query.or(buildColumnOrGroup(columns, `%${token}%`));
   }
-  if (type === 'title') {
-    return baseQuery
-      .or(`title.ilike.%${searchText}%,title_ko.ilike.%${searchText}%`)
-      .not('title', 'ilike', searchText)
-      .not('title_ko', 'ilike', searchText);
+
+  // 정확 일치 티어와의 중복 제거.
+  // nullable 컬럼(title_ko/artist_ko)에서 `col NOT ILIKE x`는 NULL로 평가되어 행이
+  // 통째로 누락되므로, `col IS NULL`을 OR로 함께 묶어 NULL-safe하게 제외한다.
+  for (const column of columns) {
+    query = query.or(`${column}.not.ilike.${phrase},${column}.is.null`);
   }
-  if (type === 'artist') {
-    return baseQuery
-      .or(`artist.ilike.%${searchText}%,artist_ko.ilike.%${searchText}%`)
-      .not('artist', 'ilike', searchText)
-      .not('artist_ko', 'ilike', searchText);
-  }
-  return baseQuery.ilike(type, `%${searchText}%`).not(type, 'ilike', searchText);
+
+  return query;
 }
 
 async function executeSearchQueries(

--- a/apps/web/src/hooks/useSearchSong.ts
+++ b/apps/web/src/hooks/useSearchSong.ts
@@ -70,13 +70,9 @@ export default function useSearchSong() {
         // 자동완성 리스트가 하나(정확히 일치하면)고 label도 일치하면 해당 alias의 value로 자동 치환
         parsedSearch = autoCompleteList[0].value;
       }
-    } else {
-      // 한글이 있다면 공백 제거
-      const hasKorean = /[가-힣ㄱ-ㅎㅏ-ㅣ]/.test(trimSearch);
-      if (hasKorean) {
-        parsedSearch = parsedSearch.replace(/ /g, '');
-      }
     }
+    // 중간 띄어쓰기는 제거하지 않고 그대로 전달한다.
+    // 검색어의 공백 처리(토큰 분리 → %로 치환)는 검색 API(/api/search)가 담당한다.
 
     if (parsedSearch) {
       setQuery(parsedSearch);


### PR DESCRIPTION
## 📌 PR 제목

### [Feat] : 검색 단어 단위 AND 매칭 및 부분 일치 NULL 누락 버그 수정

## 📌 변경 사항

- 검색어를 공백 기준 토큰으로 분리해, **입력한 모든 단어가 포함돼야 매칭(AND, 순서 무관)** 하도록 `api/search/route.ts` 필터 재작성
  - 정확 티어: `tokens.join('%')`로 띄어쓰기 차이를 무시한 완전 일치 (예: `사건의 지평선` → `사건의%지평선`)
  - 부분 티어: 각 토큰의 "컬럼 OR 그룹"을 `.or()` 체이닝으로 AND 결합 (`바톤 로드` 검색 시 `오버로드`·`로드넘버원` 같은 단어 하나만 걸친 노이즈 제외)
- **부분 일치 NULL 누락 버그 수정**: `title_ko`/`artist_ko`가 null일 때 `NOT ILIKE`가 `NULL`로 평가되어 행이 통째로 누락되던 문제를, `col IS NULL`을 OR로 묶어 NULL-safe하게 처리. (이전엔 title_ko가 채워진 J-pop만 부분 검색이 동작)
- `useSearchSong.ts`: 한글 한정 공백 제거 로직 삭제 → 공백을 보존해 API로 전달 (토큰화/공백 처리는 API가 담당)
- 가독성: 컬럼 OR 그룹 생성 로직을 `buildColumnOrGroup` 헬퍼로 추출 (DRY)

## 💬 추가 참고 사항

- 검증: build / lint / format 통과, dev 서버 라이브 API로 동작 확인 (`바톤 로드`→1건, `사건의 지평선`→1건, 단일 토큰·number·페이지네이션·정확-우선 랭킹 회귀 없음)
- web은 테스트 스위트가 없어 라이브 API 구동으로 검증
- close #254