### PR TITLE
[Refactor] : 크롤링 element selector 명확하게 지정 및 DB limit 상향 (#262)

### DIFF
--- a/packages/crawling/src/crawling/crawlTJSongByNumber.ts
+++ b/packages/crawling/src/crawling/crawlTJSongByNumber.ts
@@ -22,8 +22,8 @@ export const crawlTJSongByNumber = async (
 
   const gridContainer = $('.grid-container.list.ico').first();
 
-  const title = gridContainer.find('.grid-item.title3').text().trim();
-  const artist = gridContainer.find('.grid-item.title4').text().trim();
+  const title = gridContainer.find('.grid-item.title3 p').text().trim();
+  const artist = gridContainer.find('.grid-item.title4 p').text().trim();
 
   if (!title || !artist) {
     console.log('❌ TJ 검색 결과 없음');

--- a/packages/crawling/src/supabase/getDB.ts
+++ b/packages/crawling/src/supabase/getDB.ts
@@ -33,7 +33,7 @@ export async function getSongsJpnDB() {
   return hasJapaneseData;
 }
 
-export async function getSongsKyNullDB(max: number = 50000) {
+export async function getSongsKyNullDB(max: number = 100000) {
   const supabase = getClient();
 
   const { data, error } = await supabase
@@ -48,7 +48,7 @@ export async function getSongsKyNullDB(max: number = 50000) {
   return data;
 }
 
-export async function getSongsKyNotNullDB(max: number = 50000) {
+export async function getSongsKyNotNullDB(max: number = 100000) {
   const supabase = getClient();
 
   const { data, error } = await supabase
@@ -85,7 +85,7 @@ export async function getVerifyKySongsDB(): Promise<Set<string>> {
   return new Set(data.map(row => row.id));
 }
 
-export async function getSongsAllDB(max: number = 50000) {
+export async function getSongsAllDB(max: number = 100000) {
   const supabase = getClient();
 
   const { data, error } = await supabase
@@ -121,7 +121,7 @@ export async function getJpopSongsForTranslationDB() {
     .from('songs')
     .select('id, title, artist, title_ko, artist_ko, song_tags!inner(tag_id)')
     .eq('song_tags.tag_id', 101)
-    .limit(50000);
+    .limit(100000);
 
   if (error) throw error;
 
@@ -138,7 +138,7 @@ export async function getArtistKoMapDB(): Promise<Map<string, string>> {
     .select('artist, artist_ko, song_tags!inner(tag_id)')
     .eq('song_tags.tag_id', 101)
     .not('artist_ko', 'is', null)
-    .limit(50000);
+    .limit(100000);
 
   if (error) throw error;
 
@@ -155,7 +155,7 @@ export async function getArtistKoMapDB(): Promise<Map<string, string>> {
 export async function getSongTagSongIdsDB(): Promise<Set<string>> {
   const supabase = getClient();
 
-  const { data, error } = await supabase.from('song_tags').select('song_id').limit(50000);
+  const { data, error } = await supabase.from('song_tags').select('song_id').limit(100000);
 
   if (error) throw error;
 


### PR DESCRIPTION
## 📌 변경 사항

- `crawlTJSongByNumber.ts`: `.grid-item.title3`, `.grid-item.title4` selector에 ` p` 추가하여 내부 `p` 태그 content만 가져오도록 수정
- `getDB.ts`: 각 DB 조회 함수의 기본 limit을 50,000 → 100,000으로 상향

## 💬 추가 참고 사항

- close #262