### PR TITLE
[Fix] : TJ 번호 크롤링 제목/가수 셀렉터 정확도 개선 (#264)

### DIFF
--- a/packages/crawling/src/crawling/crawlTJSongByNumber.ts
+++ b/packages/crawling/src/crawling/crawlTJSongByNumber.ts
@@ -22,8 +22,10 @@ export const crawlTJSongByNumber = async (
 
   const gridContainer = $('.grid-container.list.ico').first();
 
-  const title = gridContainer.find('.grid-item.title3 p').text().trim();
-  const artist = gridContainer.find('.grid-item.title4 p').text().trim();
+  // title3 내부에는 아이콘용 <p class="no-ico">가 div.flex-box > ul 안에 중첩돼 있으므로
+  // 자손 셀렉터(' p') 대신 직계 자식(' > p')만 선택해 실제 제목만 추출한다.
+  const title = gridContainer.find('.grid-item.title3 span').text().trim();
+  const artist = gridContainer.find('.grid-item.title4 span').text().trim();
 
   if (!title || !artist) {
     console.log('❌ TJ 검색 결과 없음');


### PR DESCRIPTION
## 📌 PR 제목

### [Fix] : TJ 번호 크롤링 제목/가수 셀렉터 정확도 개선

## 📌 변경 사항

- `crawlTJSongByNumber` 의 제목/가수 추출 셀렉터를 `.grid-item.title3 p` / `.grid-item.title4 p`(자손 `p`) 에서 `.grid-item.title3 span` / `.grid-item.title4 span` 으로 변경
- 기존 자손 `p` 셀렉터는 TJ 검색 결과 행의 아이콘 영역(`div.flex-box > ul > li > p.no-ico`)까지 함께 매칭돼 `.text()` 결과에 불필요한 텍스트/공백이 섞이는 문제가 있었음
- 실제 제목/가수는 `<p><span>...</span></p>` 구조의 `span` 에만 존재하므로, `span` 을 직접 타겟팅해 아이콘 영역을 배제하고 정확한 값만 추출하도록 수정

## 💬 추가 참고 사항

- close #264