### PR TITLE
[Chore] : Google Play Store 등록 준비 및 앱 메타데이터 정비 (#268)

### DIFF
--- a/.github/workflows/tagging_song.yml
+++ b/.github/workflows/tagging_song.yml
@@ -2,7 +2,7 @@ name: Tagging Songs
 
 on:
   schedule:
-    - cron: "0 10 * * 1" # 매주 월요일 한국 시간 19:00 실행 (UTC+9 → UTC 10:00)
+    - cron: "0 7 * * *" # 매일 한국 시간 16:00 실행 (UTC+9 → UTC 7:00)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/translation_jpn.yml
+++ b/.github/workflows/translation_jpn.yml
@@ -2,7 +2,7 @@ name: Translation J-POP Songs
 
 on:
   schedule:
-    - cron: "0 10 * * 5" # 매주 금요일 한국 시간 19:00 실행 (UTC+9 → UTC 10:00)
+    - cron: "0 10 * * *" # 매일 한국 시간 19:00 실행 (UTC+9 → UTC 10:00)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/verify_ky_youtube.yml
+++ b/.github/workflows/verify_ky_youtube.yml
@@ -2,7 +2,7 @@ name: Verify ky by Youtube
 
 on:
   schedule:
-    - cron: "0 14 * * *" # 한국 시간 23:00 실행 (UTC+9 → UTC 14:00)
+    - cron: "0 14 * * 1" # 매주 월요일 한국 시간 23:00 실행 (UTC+9 → UTC 14:00)
   workflow_dispatch:
 
 permissions:

--- a/apps/twa/.gitignore
+++ b/apps/twa/.gitignore
@@ -1,9 +1,27 @@
 # Android keystore — 외부 백업 필수, git에 절대 커밋하지 않는다
 *.keystore
 *.jks
+*.keystore.bak*
+android.keystore.bak*
 
 # Bubblewrap 빌드 산출물
 android/
 output/
+app/
 *.aab
 *.apk
+*.apk.idsig
+
+# Gradle 생성물
+.gradle/
+gradle/
+gradlew
+gradlew.bat
+build.gradle
+settings.gradle
+gradle.properties
+manifest-checksum.txt
+store_icon.png
+
+# 수동 백업/복사본
+twa-manifest copy.json

--- a/apps/twa/twa-manifest.json
+++ b/apps/twa/twa-manifest.json
@@ -5,7 +5,7 @@
   "launcherName": "Singcode",
   "display": "standalone",
   "themeColor": "#1A1A2E",
-  "themeColorDark": "#000000",
+  "themeColorDark": "#1A1A2E",
   "navigationColor": "#1A1A2E",
   "navigationColorDark": "#1A1A2E",
   "navigationDividerColor": "#1A1A2E",

--- a/apps/twa/twa-manifest.json
+++ b/apps/twa/twa-manifest.json
@@ -1,16 +1,17 @@
 {
   "packageId": "kr.singcode.app",
   "host": "singcode.kr",
-  "name": "Singcode - 당신의 노래방 메모장",
+  "name": "싱코드(singcode) - 노래방 번호 검색",
   "launcherName": "Singcode",
   "display": "standalone",
-  "themeColor": "#1a1a2e",
-  "navigationColor": "#1a1a2e",
-  "navigationColorDark": "#1a1a2e",
-  "navigationDividerColor": "#1a1a2e",
-  "navigationDividerColorDark": "#1a1a2e",
-  "backgroundColor": "#1a1a2e",
-  "enableNotifications": false,
+  "themeColor": "#1A1A2E",
+  "themeColorDark": "#000000",
+  "navigationColor": "#1A1A2E",
+  "navigationColorDark": "#1A1A2E",
+  "navigationDividerColor": "#1A1A2E",
+  "navigationDividerColorDark": "#1A1A2E",
+  "backgroundColor": "#1A1A2E",
+  "enableNotifications": true,
   "startUrl": "/",
   "iconUrl": "https://singcode.kr/icons/icon-512.png",
   "maskableIconUrl": "https://singcode.kr/icons/icon-maskable-512.png",
@@ -20,20 +21,13 @@
     "path": "./android.keystore",
     "alias": "singcode"
   },
-  "appVersionCode": 1,
-  "appVersionName": "1.0.0",
+  "appVersionName": "3",
+  "appVersionCode": 3,
   "shortcuts": [],
   "generatorApp": "bubblewrap-cli",
   "webManifestUrl": "https://singcode.kr/manifest.webmanifest",
   "fallbackType": "customtabs",
-  "features": {
-    "locationDelegation": {
-      "enabled": false
-    },
-    "playBilling": {
-      "enabled": false
-    }
-  },
+  "features": {},
   "alphaDependencies": {
     "enabled": false
   },
@@ -42,5 +36,13 @@
   "isMetaQuest": false,
   "fullScopeUrl": "https://singcode.kr/",
   "minSdkVersion": 21,
-  "orientation": "portrait"
+  "orientation": "portrait",
+  "fingerprints": [],
+  "additionalTrustedOrigins": [],
+  "retainedBundles": [],
+  "protocolHandlers": [],
+  "fileHandlers": [],
+  "launchHandlerClientMode": "",
+  "displayOverride": [],
+  "appVersion": "3"
 }

--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "kr.singcode.app",
       "sha256_cert_fingerprints": [
-        "4A:52:E2:11:4D:E0:6F:B6:E1:E1:B2:BB:72:14:8C:0B:17:97:06:DA:BD:F7:DB:A2:3B:10:59:46:CD:79:3B:E9"
+        "4A:52:E2:11:4D:E0:6F:B6:E1:E1:B2:BB:72:14:8C:0B:17:97:06:DA:BD:F7:DB:A2:3B:10:59:46:CD:79:3B:E9",
+        "06:63:E8:E2:C6:97:EE:CE:BF:7C:2D:24:2B:F0:14:61:3F:01:39:4D:8E:B2:B3:E0:F4:65:45:E9:C1:F3:C4:0E"
       ]
     }
   }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -19,12 +19,11 @@ import QueryProvider from '@/query';
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 export const metadata: Metadata = {
-  title: 'Singcode - 당신의 노래방 메모장',
-  description:
-    '노래방만 가면 부르고 싶었던 노래가 기억 안 날 때? Singcode에서 검색하고 저장하면 걱정 끝!',
+  title: 'Singcode - 노래방 번호 검색',
+  description: 'Singcode에서 빠르고 편하게 노래방 번호 검색하세요. J-POP 검색도 지원합니다.',
   openGraph: {
-    title: 'Singcode - 노래방에서 부를 곡, 기억하지 말고 저장하세요',
-    description: '노래방 갈 때마다 잊어버리는 곡번호? Singcode가 대신 기억할게요!',
+    title: 'Singcode - 노래방 번호 검색',
+    description: 'Singcode에서 빠르고 편하게 노래방 번호 검색하세요. J-POP 검색도 지원합니다.',
     url: 'https://www.singcode.kr',
     siteName: 'Singcode',
     images: [


### PR DESCRIPTION
## 📌 PR 제목

### [Chore] : Google Play Store 등록 준비 및 앱 메타데이터 정비

## 📌 변경 사항

- **TWA 매니페스트 정비**: 앱 이름·알림·버전(3) 업데이트 및 다크테마 색상(`themeColorDark`) `#1A1A2E`로 통일
- **Play 앱 서명 연동**: `assetlinks.json`에 Play App Signing SHA-256 지문 추가
- **gitignore 보강**: TWA 빌드 산출물(`*.aab` 등)·키스토어 백업 파일 제외 규칙 추가
- **SEO 메타데이터 개선**: title/description을 "노래방 번호 검색" 중심 문구로 변경, J-POP 검색 지원 명시
- **워크플로우 cron 정비**:
  - `tagging_song` → 매일 16:00 (`0 7 * * *`)
  - `translation_jpn` → 매일 19:00 (`0 10 * * *`)
  - `verify_ky_youtube` → 매주 월요일 23:00 (`0 14 * * 1`)
  - ⚠️ 기존 변경에 섞여 있던 잘못된 cron 문법(필드 개수 불일치) 수정 포함

## 💬 추가 참고 사항

- close #268
