### PR TITLE
[Fix] : 로그인 없이 접근 가능해야 할 라우터 경로 수정 (#275)

### DIFF
--- a/apps/web/src/auth.tsx
+++ b/apps/web/src/auth.tsx
@@ -14,6 +14,8 @@ const ALLOW_PATHS = [
   '/tosing',
   '/update-password',
   '/patch-notes',
+  '/privacy',
+  '/error',
 ];
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## 📌 PR 제목

### [Fix] : 로그인 없이 접근 가능해야 할 라우터 경로 수정

## 📌 변경 사항

- `src/auth.tsx`의 `ALLOW_PATHS`에 `/privacy`, `/error` 추가
- `/privacy`(개인정보처리방침)와 `/error`(인증 오류 안내)가 비로그인 상태에서 `/login`으로 강제 리다이렉트되던 문제 수정

## 💬 추가 참고 사항

- 초기 조사 단계에서 Next.js 미들웨어(`updateSession`) 미연결 문제도 함께 검토했으나, `server.ts` 클라이언트가 Route Handler/Server Action에서만 사용되어 세션 갱신 문제가 실제로는 없음을 확인해 범위에서 제외함
- close #275