### PR TITLE
[Feat] : 노래 검색 시 song_tags 언어 태그 필터링 기능 추가 (#276)

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -45,3 +45,5 @@ next-env.d.ts
 /public/sw.js.map
 /public/swe-worker-*.js
 /public/swe-worker-*.js.map
+
+store-assets

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "axios": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "country-flag-icons": "^1.6.20",
     "date-fns": "^4.1.0",
     "es-hangul": "^2.3.8",
     "framer-motion": "^12.33.0",

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { LANGUAGE_TAGS } from '@/constants/languageTags';
 import createClient from '@/lib/supabase/server';
 import { ApiResponse } from '@/types/apiRoute';
 import { SearchSong, Song } from '@/types/song';
@@ -58,15 +59,15 @@ function buildColumnOrGroup(columns: string[], pattern: string): string {
 
 // languageTag가 있으면 song_tags(언어 태그) 조인 필터를 추가한다.
 // select 절에 `song_tags!inner(tag_id)`가 함께 포함되어 있어야 한다.
-function applyLanguageTagFilter<T extends { eq: (column: string, value: string) => T }>(
+function applyLanguageTagFilter<T extends { eq: (column: string, value: number) => T }>(
   query: T,
-  languageTag?: string,
+  languageTag?: number,
 ): T {
   return languageTag ? query.eq('song_tags.tag_id', languageTag) : query;
 }
 
 // 정확 일치: 전체 구가 한 컬럼과 일치 (랭킹 상위). 띄어쓰기 차이는 무시한다.
-function applyExactFilter(baseQuery: any, type: string, searchText: string, languageTag?: string) {
+function applyExactFilter(baseQuery: any, type: string, searchText: string, languageTag?: number) {
   if (type === 'number') {
     const query = baseQuery.or(`num_tj.eq.${searchText},num_ky.eq.${searchText}`);
     return applyLanguageTagFilter(query, languageTag);
@@ -84,7 +85,7 @@ function applyPartialFilter(
   baseQuery: any,
   type: string,
   searchText: string,
-  languageTag?: string,
+  languageTag?: number,
 ) {
   const tokens = tokenizeQuery(searchText);
   const phrase = buildPhrasePattern(tokens);
@@ -117,7 +118,7 @@ async function executeSearchQueries(
   order: string,
   from: number,
   to: number,
-  languageTag?: string,
+  languageTag?: number,
 ): Promise<{ data: DBSong[]; hasNext: boolean } | { error: string }> {
   const size = to - from + 1;
 
@@ -249,7 +250,23 @@ export async function GET(request: Request): Promise<NextResponse<ApiResponse<Se
     const type = searchParams.get('type') || 'title';
     const order = type === 'all' ? 'title' : type === 'number' ? 'num_tj' : type;
     const authenticated = searchParams.get('authenticated') === 'true';
-    const languageTag = searchParams.get('languageTag') || undefined;
+
+    const languageTagParam = searchParams.get('languageTag');
+    let languageTag: number | undefined;
+    if (languageTagParam) {
+      const parsedLanguageTag = Number.parseInt(languageTagParam, 10);
+      const isValidLanguageTag = LANGUAGE_TAGS.some(tag => tag.id === parsedLanguageTag);
+      if (!isValidLanguageTag) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: '유효하지 않은 languageTag 값입니다',
+          },
+          { status: 400 },
+        );
+      }
+      languageTag = parsedLanguageTag;
+    }
 
     const page = parseInt(searchParams.get('page') || '0', 10);
     const size = 20;

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -56,20 +56,36 @@ function buildColumnOrGroup(columns: string[], pattern: string): string {
   return columns.map(column => `${column}.ilike.${pattern}`).join(',');
 }
 
+// languageTag가 있으면 song_tags(언어 태그) 조인 필터를 추가한다.
+// select 절에 `song_tags!inner(tag_id)`가 함께 포함되어 있어야 한다.
+function applyLanguageTagFilter<T extends { eq: (column: string, value: string) => T }>(
+  query: T,
+  languageTag?: string,
+): T {
+  return languageTag ? query.eq('song_tags.tag_id', languageTag) : query;
+}
+
 // 정확 일치: 전체 구가 한 컬럼과 일치 (랭킹 상위). 띄어쓰기 차이는 무시한다.
-function applyExactFilter(baseQuery: any, type: string, searchText: string) {
+function applyExactFilter(baseQuery: any, type: string, searchText: string, languageTag?: string) {
   if (type === 'number') {
-    return baseQuery.or(`num_tj.eq.${searchText},num_ky.eq.${searchText}`);
+    const query = baseQuery.or(`num_tj.eq.${searchText},num_ky.eq.${searchText}`);
+    return applyLanguageTagFilter(query, languageTag);
   }
 
   const phrase = buildPhrasePattern(tokenizeQuery(searchText));
   const columns = getSearchColumns(type);
 
-  return baseQuery.or(buildColumnOrGroup(columns, phrase));
+  const query = baseQuery.or(buildColumnOrGroup(columns, phrase));
+  return applyLanguageTagFilter(query, languageTag);
 }
 
 // 부분 일치: 입력한 모든 토큰이 (순서 무관) 포함돼야 매칭(AND) + 정확 일치 결과는 제외.
-function applyPartialFilter(baseQuery: any, type: string, searchText: string) {
+function applyPartialFilter(
+  baseQuery: any,
+  type: string,
+  searchText: string,
+  languageTag?: string,
+) {
   const tokens = tokenizeQuery(searchText);
   const phrase = buildPhrasePattern(tokens);
   const columns = getSearchColumns(type);
@@ -90,7 +106,7 @@ function applyPartialFilter(baseQuery: any, type: string, searchText: string) {
     query = query.or(`${column}.not.ilike.${phrase},${column}.is.null`);
   }
 
-  return query;
+  return applyLanguageTagFilter(query, languageTag);
 }
 
 async function executeSearchQueries(
@@ -101,6 +117,7 @@ async function executeSearchQueries(
   order: string,
   from: number,
   to: number,
+  languageTag?: string,
 ): Promise<{ data: DBSong[]; hasNext: boolean } | { error: string }> {
   const size = to - from + 1;
 
@@ -110,11 +127,17 @@ async function executeSearchQueries(
       supabase.from('songs').select(selectClause, { count: 'exact', head: true }),
       type,
       query,
+      languageTag,
     );
     if (exactCountResult.error) return { error: exactCountResult.error.message };
     const exactTotal = exactCountResult.count ?? 0;
 
-    const exactQuery = applyExactFilter(supabase.from('songs').select(selectClause), type, query);
+    const exactQuery = applyExactFilter(
+      supabase.from('songs').select(selectClause),
+      type,
+      query,
+      languageTag,
+    );
     const { data, error } = await exactQuery.order(order).range(from, to);
     if (error) return { error: error.message };
 
@@ -134,11 +157,13 @@ async function executeSearchQueries(
     supabase.from('songs').select(selectClause, { count: 'exact', head: true }),
     type,
     query,
+    languageTag,
   );
   const partialCountQuery = applyPartialFilter(
     supabase.from('songs').select(selectClause, { count: 'exact', head: true }),
     type,
     query,
+    languageTag,
   );
 
   const [exactCountResult, partialCountResult] = await Promise.all([
@@ -163,6 +188,7 @@ async function executeSearchQueries(
       supabase.from('songs').select(selectClause),
       type,
       query,
+      languageTag,
     );
     const { data, error } = await partialQuery.order(order).range(from, to);
     if (error) return { error: error.message };
@@ -175,6 +201,7 @@ async function executeSearchQueries(
       supabase.from('songs').select(selectClause),
       type,
       query,
+      languageTag,
     );
     const { data, error } = await partialQuery.order(order).range(partialFrom, partialTo);
     if (error) return { error: error.message };
@@ -182,7 +209,12 @@ async function executeSearchQueries(
   } else {
     // 현재 페이지가 정확 일치 영역에 포함 (경계에 걸릴 수도 있음)
     const exactTo = Math.min(to, exactTotal - 1);
-    const exactQuery = applyExactFilter(supabase.from('songs').select(selectClause), type, query);
+    const exactQuery = applyExactFilter(
+      supabase.from('songs').select(selectClause),
+      type,
+      query,
+      languageTag,
+    );
     const exactResult = await exactQuery.order(order).range(from, exactTo);
     if (exactResult.error) return { error: exactResult.error.message };
     exactData = (exactResult.data as DBSong[]) ?? [];
@@ -194,6 +226,7 @@ async function executeSearchQueries(
         supabase.from('songs').select(selectClause),
         type,
         query,
+        languageTag,
       );
       const partialResult = await partialQuery.order(order).range(0, partialTo);
       if (partialResult.error) return { error: partialResult.error.message };
@@ -216,6 +249,7 @@ export async function GET(request: Request): Promise<NextResponse<ApiResponse<Se
     const type = searchParams.get('type') || 'title';
     const order = type === 'all' ? 'title' : type === 'number' ? 'num_tj' : type;
     const authenticated = searchParams.get('authenticated') === 'true';
+    const languageTag = searchParams.get('languageTag') || undefined;
 
     const page = parseInt(searchParams.get('page') || '0', 10);
     const size = 20;
@@ -234,11 +268,25 @@ export async function GET(request: Request): Promise<NextResponse<ApiResponse<Se
 
     const supabase = await createClient();
 
-    const selectClause = authenticated
+    const baseSelectClause = authenticated
       ? `*, thumb_logs(*), tosings(user_id), like_activities(user_id), save_activities(user_id)`
       : `*, thumb_logs(*)`;
+    // languageTag로 필터링할 때만 song_tags를 inner join으로 함께 select한다.
+    // (그 외에는 태그 없는 곡이 결과에서 누락되지 않도록 조인하지 않는다)
+    const selectClause = languageTag
+      ? `${baseSelectClause}, song_tags!inner(tag_id)`
+      : baseSelectClause;
 
-    const result = await executeSearchQueries(supabase, selectClause, query, type, order, from, to);
+    const result = await executeSearchQueries(
+      supabase,
+      selectClause,
+      query,
+      type,
+      order,
+      from,
+      to,
+      languageTag,
+    );
 
     if ('error' in result) {
       return NextResponse.json(

--- a/apps/web/src/app/search/HomePage.tsx
+++ b/apps/web/src/app/search/HomePage.tsx
@@ -17,6 +17,7 @@ import { SearchSong } from '@/types/song';
 import AddFolderModal from './AddFolderModal';
 // import ChatBot from './ChatBot';
 import JpnArtistList from './JpnArtistList';
+import LanguageTagFilter from './LanguageTagFilter';
 import PopularSearchHistory from './PopularSearchHistory';
 import SearchAutocomplete from './SearchAutocomplete';
 import SearchHistory from './SearchHistory';
@@ -31,6 +32,8 @@ export default function SearchPage() {
     autoCompleteList,
     query,
     queryType,
+    languageTag,
+    queryLanguageTag,
 
     searchResults,
     isPendingSearch,
@@ -40,6 +43,7 @@ export default function SearchPage() {
     isError,
 
     handleSearchTypeChange,
+    handleLanguageTagChange,
     handleSearch,
     handleToggleToSing,
     handleToggleLike,
@@ -54,7 +58,7 @@ export default function SearchPage() {
     handleToggleSave,
     postSaveSong,
     patchSaveSong,
-  } = useSaveSongModal(query, queryType);
+  } = useSaveSongModal(query, queryType, queryLanguageTag);
 
   const [isJpnArtistModalOpen, setIsJpnArtistModalOpen] = useState(false);
   const [isFocusAuto, setIsFocusAuto] = useState(false);
@@ -219,6 +223,8 @@ export default function SearchPage() {
             {isPendingSearch ? <Loader2 className="h-4 w-4 animate-spin" /> : '검색'}
           </Button>
         </div>
+
+        <LanguageTagFilter value={languageTag} onChange={handleLanguageTagChange} />
       </div>
       <div ref={setScrollRef} className="h-[calc(100vh-22rem)] overflow-x-hidden overflow-y-auto">
         {searchSongs.length > 0 && (

--- a/apps/web/src/app/search/LanguageTagFilter.tsx
+++ b/apps/web/src/app/search/LanguageTagFilter.tsx
@@ -1,0 +1,59 @@
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { LANGUAGE_TAGS } from '@/constants/languageTags';
+import { cn } from '@/utils/cn';
+
+const ALL_VALUE = 'all';
+
+// Tailwind는 클래스명을 정적으로 스캔하므로, 색상 클래스는 태그마다 완전한 문자열로 나열해야 한다.
+// 태그별로 chart-1/2/4/5 네온 컬러를 고정 배정해 "노래방 네온 칩" 느낌을 낸다.
+// 선택 시에는 해당 색으로 배경을 가득 채우고 글자색을 흰색으로 바꿔 명확히 구분한다.
+// TabsTrigger 기본 스타일에 dark:data-[state=active]:bg-input/30, dark:data-[state=active]:text-foreground가
+// 이미 있어서, dark: 접두사가 없는 클래스는 variant 체인이 달라 tailwind-merge가 덮어쓰지 못한다.
+// 다크모드용도 명시적으로 함께 지정해야 실제로 배경/글자색이 바뀐다.
+const TAG_ACCENT_CLASSES: Record<number, string> = {
+  100: 'border-chart-1/40 text-chart-1/80 data-[state=active]:border-chart-1 data-[state=active]:bg-chart-1 data-[state=active]:text-white dark:data-[state=active]:border-chart-1 dark:data-[state=active]:bg-chart-1 dark:data-[state=active]:text-white data-[state=active]:shadow-[0_0_10px_var(--chart-1)]',
+  101: 'border-chart-2/40 text-chart-2/80 data-[state=active]:border-chart-2 data-[state=active]:bg-chart-2 data-[state=active]:text-white dark:data-[state=active]:border-chart-2 dark:data-[state=active]:bg-chart-2 dark:data-[state=active]:text-white data-[state=active]:shadow-[0_0_10px_var(--chart-2)]',
+  102: 'border-chart-4/40 text-chart-4/80 data-[state=active]:border-chart-4 data-[state=active]:bg-chart-4 data-[state=active]:text-white dark:data-[state=active]:border-chart-4 dark:data-[state=active]:bg-chart-4 dark:data-[state=active]:text-white data-[state=active]:shadow-[0_0_10px_var(--chart-4)]',
+  103: 'border-chart-5/40 text-chart-5/80 data-[state=active]:border-chart-5 data-[state=active]:bg-chart-5 data-[state=active]:text-white dark:data-[state=active]:border-chart-5 dark:data-[state=active]:bg-chart-5 dark:data-[state=active]:text-white data-[state=active]:shadow-[0_0_10px_var(--chart-5)]',
+};
+
+// "전체"는 특정 언어를 대표하지 않으므로 네온 글로우 없이 중립 톤(전경색 가득 채움)만 유지한다.
+const ALL_ACCENT_CLASSES =
+  'border-border text-muted-foreground data-[state=active]:border-foreground data-[state=active]:bg-foreground data-[state=active]:text-background dark:data-[state=active]:border-foreground dark:data-[state=active]:bg-foreground dark:data-[state=active]:text-background data-[state=active]:shadow-none';
+
+const CHIP_BASE_CLASSES =
+  'flex-none rounded-full border bg-transparent px-3 py-1.5 font-medium shadow-none transition-all';
+
+interface LanguageTagFilterProps {
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+}
+
+export default function LanguageTagFilter({ value, onChange }: LanguageTagFilterProps) {
+  const handleValueChange = (next: string) => {
+    onChange(next === ALL_VALUE ? undefined : Number(next));
+  };
+
+  return (
+    <Tabs
+      value={value ? String(value) : ALL_VALUE}
+      onValueChange={handleValueChange}
+      className="w-full"
+    >
+      <TabsList className="h-auto w-full flex-wrap justify-start gap-2 bg-transparent p-0">
+        <TabsTrigger value={ALL_VALUE} className={cn(CHIP_BASE_CLASSES, ALL_ACCENT_CLASSES)}>
+          전체
+        </TabsTrigger>
+        {LANGUAGE_TAGS.map(tag => (
+          <TabsTrigger
+            key={tag.id}
+            value={String(tag.id)}
+            className={cn(CHIP_BASE_CLASSES, TAG_ACCENT_CLASSES[tag.id])}
+          >
+            {tag.name}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/apps/web/src/app/search/LanguageTagFilter.tsx
+++ b/apps/web/src/app/search/LanguageTagFilter.tsx
@@ -1,3 +1,5 @@
+import { JP, KR, US } from 'country-flag-icons/react/3x2';
+
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { LANGUAGE_TAGS } from '@/constants/languageTags';
 import { cn } from '@/utils/cn';
@@ -22,7 +24,18 @@ const ALL_ACCENT_CLASSES =
   'border-border text-muted-foreground data-[state=active]:border-foreground data-[state=active]:bg-foreground data-[state=active]:text-background dark:data-[state=active]:border-foreground dark:data-[state=active]:bg-foreground dark:data-[state=active]:text-background data-[state=active]:shadow-none';
 
 const CHIP_BASE_CLASSES =
-  'flex-none rounded-full border bg-transparent px-3 py-1.5 font-medium shadow-none transition-all';
+  'flex-none rounded-full border bg-transparent px-2.5 py-1.5  font-medium shadow-none transition-all';
+
+const ALL_EMOJI = '🎵';
+
+const FLAG_CLASSES = 'h-3 w-auto rounded-[2px]';
+
+const TAG_ICONS: Record<number, React.ReactNode> = {
+  100: <KR title="한국어" className={FLAG_CLASSES} />,
+  101: <JP title="일본어" className={FLAG_CLASSES} />,
+  102: <US title="영어" className={FLAG_CLASSES} />,
+  103: '🌐',
+};
 
 interface LanguageTagFilterProps {
   value: number | undefined;
@@ -40,9 +53,9 @@ export default function LanguageTagFilter({ value, onChange }: LanguageTagFilter
       onValueChange={handleValueChange}
       className="w-full"
     >
-      <TabsList className="h-auto w-full flex-wrap justify-start gap-2 bg-transparent p-0">
+      <TabsList className="h-auto w-full flex-wrap justify-start gap-1 bg-transparent p-0">
         <TabsTrigger value={ALL_VALUE} className={cn(CHIP_BASE_CLASSES, ALL_ACCENT_CLASSES)}>
-          전체
+          {ALL_EMOJI} 전체
         </TabsTrigger>
         {LANGUAGE_TAGS.map(tag => (
           <TabsTrigger
@@ -50,7 +63,7 @@ export default function LanguageTagFilter({ value, onChange }: LanguageTagFilter
             value={String(tag.id)}
             className={cn(CHIP_BASE_CLASSES, TAG_ACCENT_CLASSES[tag.id])}
           >
-            {tag.name}
+            {TAG_ICONS[tag.id]} {tag.name}
           </TabsTrigger>
         ))}
       </TabsList>

--- a/apps/web/src/constants/languageTags.ts
+++ b/apps/web/src/constants/languageTags.ts
@@ -1,0 +1,8 @@
+import { Tag } from '@/types/tag';
+
+export const LANGUAGE_TAGS: Tag[] = [
+  { id: 100, name: '한국노래' },
+  { id: 101, name: 'J-POP' },
+  { id: 102, name: 'POP' },
+  { id: 103, name: '글로벌' },
+];

--- a/apps/web/src/hooks/useSaveSongModal.ts
+++ b/apps/web/src/hooks/useSaveSongModal.ts
@@ -10,7 +10,11 @@ import { SearchSong, SearchType } from '@/types/song';
 
 type SaveModalType = '' | 'POST' | 'PATCH';
 
-export default function useSaveSongModal(query: string, queryType: SearchType) {
+export default function useSaveSongModal(
+  query: string,
+  queryType: SearchType,
+  languageTag?: number,
+) {
   const { isAuthenticated } = useAuthStore();
   const { setFooterAnimateKey } = useFooterAnimateStore();
 
@@ -37,7 +41,7 @@ export default function useSaveSongModal(query: string, queryType: SearchType) {
     }
 
     setFooterAnimateKey('INFO');
-    postSong({ songId, folderName, query, searchType: queryType });
+    postSong({ songId, folderName, query, searchType: queryType, languageTag });
   };
 
   const patchSaveSong = async (songId: string, folderId: string) => {

--- a/apps/web/src/hooks/useSearchSong.ts
+++ b/apps/web/src/hooks/useSearchSong.ts
@@ -22,14 +22,19 @@ export default function useSearchSong() {
   const [searchType, setSearchType] = useState<SearchType>('all');
   const [query, setQuery] = useState('');
   const [queryType, setQueryType] = useState<SearchType>('all');
+  // languageTag: Tabs에서 선택 중인(draft) 값. queryLanguageTag: 검색 실행 시 커밋되어 실제 쿼리에 쓰이는 값.
+  const [languageTag, setLanguageTag] = useState<number | undefined>(undefined);
+  const [queryLanguageTag, setQueryLanguageTag] = useState<number | undefined>(undefined);
 
   const { mutate: toggleToSing, isPending: isToggleToSingPending } = useToggleToSingMutation(
     query,
     queryType,
+    queryLanguageTag,
   );
   const { mutate: toggleLike, isPending: isToggleLikePending } = useToggleLikeMutation(
     query,
     queryType,
+    queryLanguageTag,
   );
 
   const {
@@ -39,7 +44,7 @@ export default function useSearchSong() {
     isFetchingNextPage,
     isLoading: isPendingSearch,
     isError,
-  } = useInfiniteSearchSongQuery(query, queryType, isAuthenticated);
+  } = useInfiniteSearchSongQuery(query, queryType, isAuthenticated, queryLanguageTag);
 
   const { mutate: postSearchLog } = usePostSearchLogMutation();
 
@@ -78,6 +83,7 @@ export default function useSearchSong() {
       setQuery(parsedSearch);
       setSearch(parsedSearch);
       setQueryType(searchType);
+      setQueryLanguageTag(languageTag);
       addToHistory(parsedSearch);
       postSearchLog(parsedSearch);
     }
@@ -85,6 +91,10 @@ export default function useSearchSong() {
 
   const handleSearchTypeChange = (value: string) => {
     setSearchType(value as SearchType);
+  };
+
+  const handleLanguageTagChange = (value: number | undefined) => {
+    setLanguageTag(value);
   };
 
   const handleToggleToSing = async (song: Song, method: Method) => {
@@ -133,6 +143,8 @@ export default function useSearchSong() {
     autoCompleteList,
     query,
     queryType,
+    languageTag,
+    queryLanguageTag,
 
     searchResults,
     fetchNextPage,
@@ -142,6 +154,7 @@ export default function useSearchSong() {
     isError,
 
     handleSearchTypeChange,
+    handleLanguageTagChange,
     handleSearch,
     handleToggleToSing,
     handleToggleLike,

--- a/apps/web/src/lib/api/searchSong.ts
+++ b/apps/web/src/lib/api/searchSong.ts
@@ -16,17 +16,3 @@ export async function getInfiniteSearchSong(
 
   return response.data;
 }
-
-export async function getSearchSong(
-  search: string,
-  searchType: string,
-  isAuthenticated: boolean,
-  page?: number,
-  languageTag?: number,
-) {
-  const response = await instance.get<ApiResponse<SearchSong[]>>('/search', {
-    params: { q: search, type: searchType, authenticated: isAuthenticated, page, languageTag },
-  });
-
-  return response.data;
-}

--- a/apps/web/src/lib/api/searchSong.ts
+++ b/apps/web/src/lib/api/searchSong.ts
@@ -8,9 +8,10 @@ export async function getInfiniteSearchSong(
   searchType: string,
   isAuthenticated: boolean,
   page?: number,
+  languageTag?: number,
 ) {
   const response = await instance.get<ApiResponse<SearchSong[]>>('/search', {
-    params: { q: search, type: searchType, authenticated: isAuthenticated, page },
+    params: { q: search, type: searchType, authenticated: isAuthenticated, page, languageTag },
   });
 
   return response.data;
@@ -21,9 +22,10 @@ export async function getSearchSong(
   searchType: string,
   isAuthenticated: boolean,
   page?: number,
+  languageTag?: number,
 ) {
   const response = await instance.get<ApiResponse<SearchSong[]>>('/search', {
-    params: { q: search, type: searchType, authenticated: isAuthenticated, page },
+    params: { q: search, type: searchType, authenticated: isAuthenticated, page, languageTag },
   });
 
   return response.data;

--- a/apps/web/src/queries/searchSongQuery.ts
+++ b/apps/web/src/queries/searchSongQuery.ts
@@ -1,8 +1,8 @@
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { deleteLikeSong, postLikeSong } from '@/lib/api/likeSong';
 import { postSaveSong } from '@/lib/api/saveSong';
-import { getInfiniteSearchSong, getSearchSong } from '@/lib/api/searchSong';
+import { getInfiniteSearchSong } from '@/lib/api/searchSong';
 import { deleteToSingSong, postToSingSong } from '@/lib/api/tosing';
 import { Method } from '@/types/common';
 import { SearchSong } from '@/types/song';
@@ -68,27 +68,6 @@ export const useInfiniteSearchSongQuery = (
     },
     initialPageParam: 0,
     enabled: !!search,
-  });
-};
-
-export const useSearchSongQuery = (
-  search: string,
-  searchType: string,
-  isAuthenticated: boolean,
-) => {
-  return useQuery<SearchSong[]>({
-    queryKey: ['searchSong', search, searchType],
-    queryFn: async () => {
-      const response = await getSearchSong(search, searchType, isAuthenticated);
-      if (!response.success) {
-        return [];
-      }
-      return response.data || [];
-    },
-    enabled: !!search,
-    // DB의 값은 고정된 값이므로 캐시를 유지한다
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 5,
   });
 };
 

--- a/apps/web/src/queries/searchSongQuery.ts
+++ b/apps/web/src/queries/searchSongQuery.ts
@@ -30,17 +30,25 @@ interface FolderProps {
   folderName: string;
   query: string;
   searchType: string;
+  languageTag?: number;
 }
 
 export const useInfiniteSearchSongQuery = (
   search: string,
   searchType: string,
   isAuthenticated: boolean,
+  languageTag?: number,
 ) => {
   return useInfiniteQuery({
-    queryKey: ['searchSong', search, searchType],
+    queryKey: ['searchSong', search, searchType, languageTag],
     queryFn: async ({ pageParam }) => {
-      const response = await getInfiniteSearchSong(search, searchType, isAuthenticated, pageParam);
+      const response = await getInfiniteSearchSong(
+        search,
+        searchType,
+        isAuthenticated,
+        pageParam,
+        languageTag,
+      );
 
       if (!response.success) {
         throw new Error('Search API failed');
@@ -84,7 +92,11 @@ export const useSearchSongQuery = (
   });
 };
 
-export const useToggleToSingMutation = (query: string, searchType: string) => {
+export const useToggleToSingMutation = (
+  query: string,
+  searchType: string,
+  languageTag?: number,
+) => {
   const queryClient = useQueryClient();
   return useMutation({
     // 낙관적 업데이트 검증 코드
@@ -98,31 +110,32 @@ export const useToggleToSingMutation = (query: string, searchType: string) => {
       }
     },
     onMutate: async ({ songId, method }: SongProps) => {
-      await queryClient.cancelQueries({ queryKey: ['searchSong', query, searchType] });
-      const prev = queryClient.getQueryData(['searchSong', query, searchType]);
+      const queryKey = ['searchSong', query, searchType, languageTag];
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
       const isToSing = method === 'POST';
 
-      queryClient.setQueryData(
-        ['searchSong', query, searchType],
-        (old: NextPageParamType | undefined) => {
-          if (!old) return old;
+      queryClient.setQueryData(queryKey, (old: NextPageParamType | undefined) => {
+        if (!old) return old;
 
-          return {
-            ...old,
-            pages: old.pages.map((page: { data: SearchSong[]; hasNext: boolean }) => ({
-              ...page,
-              data: page.data.map(song => (song.id === songId ? { ...song, isToSing } : song)),
-            })),
-          };
-        },
-      );
+        return {
+          ...old,
+          pages: old.pages.map((page: { data: SearchSong[]; hasNext: boolean }) => ({
+            ...page,
+            data: page.data.map(song => (song.id === songId ? { ...song, isToSing } : song)),
+          })),
+        };
+      });
 
-      return { prev, query, searchType };
+      return { prev, query, searchType, languageTag };
     },
     onError: (error, variables, context) => {
       console.error('error', error);
       alert(error.message ?? 'POST 실패');
-      queryClient.setQueryData(['searchSong', context?.query, context?.searchType], context?.prev);
+      queryClient.setQueryData(
+        ['searchSong', context?.query, context?.searchType, context?.languageTag],
+        context?.prev,
+      );
     },
     onSettled: () => {
       if (invalidateToSingTimeout) {
@@ -130,7 +143,7 @@ export const useToggleToSingMutation = (query: string, searchType: string) => {
       }
       invalidateToSingTimeout = setTimeout(() => {
         queryClient.invalidateQueries({
-          queryKey: ['searchSong', query, searchType],
+          queryKey: ['searchSong', query, searchType, languageTag],
         });
         queryClient.invalidateQueries({ queryKey: ['toSingSong'] });
       }, 1000);
@@ -138,7 +151,7 @@ export const useToggleToSingMutation = (query: string, searchType: string) => {
   });
 };
 
-export const useToggleLikeMutation = (query: string, searchType: string) => {
+export const useToggleLikeMutation = (query: string, searchType: string, languageTag?: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -150,30 +163,31 @@ export const useToggleLikeMutation = (query: string, searchType: string) => {
       }
     },
     onMutate: async ({ songId, method }: SongProps) => {
-      await queryClient.cancelQueries({ queryKey: ['searchSong', query, searchType] });
-      const prev = queryClient.getQueryData(['searchSong', query, searchType]);
+      const queryKey = ['searchSong', query, searchType, languageTag];
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
       const isLike = method === 'POST';
-      queryClient.setQueryData(
-        ['searchSong', query, searchType],
-        (old: NextPageParamType | undefined) => {
-          if (!old) return old;
+      queryClient.setQueryData(queryKey, (old: NextPageParamType | undefined) => {
+        if (!old) return old;
 
-          return {
-            ...old,
-            pages: old.pages.map((page: { data: SearchSong[]; hasNext: boolean }) => ({
-              ...page,
-              data: page.data.map(song => (song.id === songId ? { ...song, isLike } : song)),
-            })),
-          };
-        },
-      );
+        return {
+          ...old,
+          pages: old.pages.map((page: { data: SearchSong[]; hasNext: boolean }) => ({
+            ...page,
+            data: page.data.map(song => (song.id === songId ? { ...song, isLike } : song)),
+          })),
+        };
+      });
 
-      return { prev, query, searchType };
+      return { prev, query, searchType, languageTag };
     },
     onError: (error, variables, context) => {
       console.error('error', error);
       alert(error.message ?? 'POST 실패');
-      queryClient.setQueryData(['searchSong', context?.query, context?.searchType], context?.prev);
+      queryClient.setQueryData(
+        ['searchSong', context?.query, context?.searchType, context?.languageTag],
+        context?.prev,
+      );
     },
     onSettled: () => {
       if (invalidateLikeTimeout) {
@@ -181,7 +195,7 @@ export const useToggleLikeMutation = (query: string, searchType: string) => {
       }
       invalidateLikeTimeout = setTimeout(() => {
         queryClient.invalidateQueries({
-          queryKey: ['searchSong', query, searchType],
+          queryKey: ['searchSong', query, searchType, languageTag],
         });
         queryClient.invalidateQueries({ queryKey: ['likeSong'] });
       }, 1000);
@@ -196,35 +210,36 @@ export const useSaveMutation = () => {
     mutationFn: ({ songId, folderName }: FolderProps) => {
       return postSaveSong({ songId, folderName });
     },
-    onMutate: async ({ songId, query, searchType }: FolderProps) => {
-      await queryClient.cancelQueries({ queryKey: ['searchSong', query, searchType] });
-      const prev = queryClient.getQueryData(['searchSong', query, searchType]);
+    onMutate: async ({ songId, query, searchType, languageTag }: FolderProps) => {
+      const queryKey = ['searchSong', query, searchType, languageTag];
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
 
-      queryClient.setQueryData(
-        ['searchSong', query, searchType],
-        (old: NextPageParamType | undefined) => {
-          if (!old) return old;
+      queryClient.setQueryData(queryKey, (old: NextPageParamType | undefined) => {
+        if (!old) return old;
 
-          return {
-            ...old,
-            pages: old.pages.map((page: { data: SearchSong[]; hasNext: boolean }) => ({
-              ...page,
-              data: page.data.map(song => (song.id === songId ? { ...song, isSave: true } : song)),
-            })),
-          };
-        },
-      );
+        return {
+          ...old,
+          pages: old.pages.map((page: { data: SearchSong[]; hasNext: boolean }) => ({
+            ...page,
+            data: page.data.map(song => (song.id === songId ? { ...song, isSave: true } : song)),
+          })),
+        };
+      });
 
-      return { prev, query, searchType };
+      return { prev, query, searchType, languageTag };
     },
     onError: (error, variables, context) => {
       console.error('error', error);
       alert(error.message ?? 'POST 실패');
-      queryClient.setQueryData(['searchSong', context?.query, context?.searchType], context?.prev);
+      queryClient.setQueryData(
+        ['searchSong', context?.query, context?.searchType, context?.languageTag],
+        context?.prev,
+      );
     },
     onSettled: (data, error, context) => {
       queryClient.invalidateQueries({
-        queryKey: ['searchSong', context?.query, context?.searchType],
+        queryKey: ['searchSong', context?.query, context?.searchType, context?.languageTag],
       });
       queryClient.invalidateQueries({ queryKey: ['saveSongFolder'] });
       queryClient.invalidateQueries({ queryKey: ['saveSongFolderList'] });

--- a/apps/web/src/types/tag.ts
+++ b/apps/web/src/types/tag.ts
@@ -1,0 +1,4 @@
+export interface Tag {
+  id: number;
+  name: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      country-flag-icons:
+        specifier: ^1.6.20
+        version: 1.6.20
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1179,11 +1182,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@maxim_mazurok/gapi.client.androidpublisher-v3@0.3.20260316':
-    resolution: {integrity: sha512-nBwcwZ4306W3E1kuB6gMKX1X2v+9OSOgcaBsruLm5M4Qp2SG+R0+Yq71tu8oJyLrk+XR2kULbQY7vBPvBKNS3g==}
+  '@maxim_mazurok/gapi.client.androidpublisher-v3@0.4.20260706':
+    resolution: {integrity: sha512-s8lamOTlLYOOmP0XDzjbf49levLsnfUrLyLS4gSaomCUoJ0RwDwsoZIfae5XLThGPJb6QCFqXUrmqUK2o44+mA==}
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
-    resolution: {integrity: sha512-oVq9hnnI5VhAtsx55iJbPz8NRfJtWFpI1kINKeuygzCvsx90b1GQDeN3MDUvhADXiQ7+Izs316cqBnJjoDxCow==}
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
+    resolution: {integrity: sha512-QN6aGmIbLXcJW0SEf8tz9UWCpQTBMy2u4xSuZ04YofzMGknhWwMeUecySLntCZYAEstHzDoSgwxCf5Gb8GqIRQ==}
 
   '@next/bundle-analyzer@15.5.9':
     resolution: {integrity: sha512-lT1EBpFyGVN9u8M43f2jE78DsCu0A5KPA5OkF5PdIHrKDo4oTJ4lUQKciA9T2u9gccSXIPQcZb5TYkHF4f8iiw==}
@@ -3127,6 +3130,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  country-flag-icons@1.6.20:
+    resolution: {integrity: sha512-py8JiEKzjhYw6HPJ0L7SxLgCYim36UPRTZX43/kqGueUCZLSvnrqAiwW8HtQibur7mdkFQUkjOgdK+o/9FBtaw==}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -6579,12 +6585,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@maxim_mazurok/gapi.client.androidpublisher-v3@0.3.20260316':
+  '@maxim_mazurok/gapi.client.androidpublisher-v3@0.4.20260706':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
@@ -7831,11 +7837,11 @@ snapshots:
 
   '@types/gapi.client.androidpublisher@3.0.2':
     dependencies:
-      '@maxim_mazurok/gapi.client.androidpublisher-v3': 0.3.20260316
+      '@maxim_mazurok/gapi.client.androidpublisher-v3': 0.4.20260706
 
   '@types/gapi.client.discovery-v1@0.0.4':
     dependencies:
-      '@maxim_mazurok/gapi.client.discovery-v1': 0.5.20200806
+      '@maxim_mazurok/gapi.client.discovery-v1': 0.6.20200806
 
   '@types/gapi.client@1.0.8': {}
 
@@ -8540,6 +8546,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  country-flag-icons@1.6.20: {}
 
   create-require@1.1.1: {}
 


### PR DESCRIPTION
## 📌 PR 제목

### [Feat] : 노래 검색 시 song_tags 언어 태그 필터링 기능 추가

## 📌 변경 사항

- `/api/search`에 `languageTag` 쿼리 파라미터 추가 — 지정 시 `song_tags!inner(tag_id)` 조인으로 언어 태그 필터링, 미지정 시 기존 동작 그대로 유지(태그 없는 곡도 정상 노출)
- 언어 태그 목록(`한국노래/J-POP/POP/글로벌`, tag_id 100~103)은 DB 조회 대신 `src/constants/languageTags.ts`에 하드코딩 상수로 관리
- 검색 페이지에 `LanguageTagFilter` 컴포넌트 추가 — 검색 입력창 아래, Tabs 기반 네온 컬러 칩 UI(태그별 chart-1/2/4/5 색상, 선택 시 해당 색으로 배경 채움 + glow)
- 태그 선택은 draft 상태로만 반영되고, "검색" 버튼/Enter로 `handleSearch()` 실행 시에만 실제 쿼리에 커밋되도록 처리 (기존 검색어/검색타입과 동일한 draft-commit 패턴)
- `useToggleToSingMutation`/`useToggleLikeMutation`/`useSaveMutation`의 쿼리 키에도 `languageTag`를 포함시켜, 필터가 걸린 상태에서도 좋아요/부를곡 토글의 낙관적 업데이트가 정상 동작하도록 수정

## 💬 추가 참고 사항

- close #276