### PR TITLE
[Fix] : 모바일 Header 버튼 확장 시 nav 넘침 수정 (#284)

### DIFF
--- a/apps/web/src/Header.tsx
+++ b/apps/web/src/Header.tsx
@@ -109,7 +109,7 @@ export default function Header() {
         <ExpandableButton
           buttonKey="theme"
           expanded={expanded}
-          label={theme === 'dark' ? '라이트 모드' : '다크 모드'}
+          label={theme === 'dark' ? '라이트' : '다크'}
           icon={
             <span className="relative h-4 w-4">
               <Sun className="absolute h-4 w-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
@@ -124,7 +124,7 @@ export default function Header() {
         <ExpandableButton
           buttonKey="checkin"
           expanded={expanded}
-          label="출석체크"
+          label="출석"
           icon={<CalendarCheck className="h-4 w-4" />}
           disabled={isLoading}
           onClick={() => handleExpandableClick('checkin', () => setOpen(true))}


### PR DESCRIPTION
## 📌 PR 제목

### [Fix] : 모바일 Header 버튼 확장 시 nav 넘침 수정

## 📌 변경 사항

- 다크모드 토글 버튼 라벨을 "라이트 모드"/"다크 모드" → "라이트"/"다크"로 축약
- 출석체크 버튼 라벨을 "출석체크" → "출석"으로 축약
- 확장 버튼 클릭 시 늘어나는 폭 자체를 줄여, 좁은 모바일 뷰포트에서 header nav가 화면 밖으로 삐져나오는 현상을 근본적으로 방지

## 💬 추가 참고 사항

- close #284