### PR TITLE
[Fix] : 검색 사용법 투어 툴팁 모바일 너비 오버플로우 수정 (#292)

### DIFF
--- a/apps/twa/twa-manifest.json
+++ b/apps/twa/twa-manifest.json
@@ -21,8 +21,8 @@
     "path": "./android.keystore",
     "alias": "singcode"
   },
-  "appVersionName": "7",
-  "appVersionCode": 7,
+  "appVersionName": "8",
+  "appVersionCode": 8,
   "shortcuts": [],
   "generatorApp": "bubblewrap-cli",
   "webManifestUrl": "https://www.singcode.kr/manifest.webmanifest",
@@ -44,5 +44,5 @@
   "fileHandlers": [],
   "launchHandlerClientMode": "",
   "displayOverride": [],
-  "appVersion": "7"
+  "appVersion": "8"
 }

--- a/apps/web/src/app/search/SearchTour.tsx
+++ b/apps/web/src/app/search/SearchTour.tsx
@@ -145,6 +145,9 @@ export default function SearchTour({
       showProgress: true,
       buttons: TOOLTIP_BUTTONS,
       skipBeacon: true,
+      // 라이브러리 기본값(고정 380px)은 375px 이하 모바일 화면에서 좌우로 넘친다.
+      // 뷰포트보다 넓어지지 않되, 넓은 화면에서는 기존 380px 상한을 유지한다.
+      width: 'min(380px, calc(100vw - 32px))',
     }),
     [isDark],
   );


### PR DESCRIPTION
## 📌 PR 제목

### [Fix] : 검색 사용법 투어 툴팁 모바일 너비 오버플로우 수정

## 📌 변경 사항

- react-joyride 기본 고정 너비(380px)가 375px 이하 모바일 화면에서 좌우로 넘치던 문제를 `width: min(380px, calc(100vw - 32px))`로 해결
- 넓은 화면(태블릿/데스크톱)에서는 기존 380px 상한을 그대로 유지해 회귀 없음
- Playwright로 360px/375px/1280px 뷰포트, 투어 10단계 전체를 순회하며 오버플로우 없음을 실측 확인
- (참고) `apps/twa/twa-manifest.json`의 TWA 앱 버전(7→8) 변경 커밋이 이 브랜치에 함께 포함되어 있습니다 — 이 PR의 작업 범위(#292)와는 무관하며, 로컬에서 별도로 생성된 커밋입니다.

## 💬 추가 참고 사항

- close #292