### PR TITLE
Feat : TJ 공식 차트 API 연동으로 popular 페이지 개편 (#295)

### DIFF
--- a/.github/workflows/crawl_tj_chart.yml
+++ b/.github/workflows/crawl_tj_chart.yml
@@ -1,0 +1,38 @@
+name: Crawl TJ Chart
+
+on:
+  schedule:
+    - cron: "0 1 1 * *" # 매달 1일 KST 오전 10:00 실행 (UTC+9 → UTC 01:00)
+  workflow_dispatch:
+
+jobs:
+  run-npm-task:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        working-directory: packages/crawling
+        run: pnpm install
+
+      - name: Create .env file
+        working-directory: packages/crawling
+        run: |
+          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}" >> .env
+
+      - name: run crawl script - crawlTjChart.ts
+        working-directory: packages/crawling
+        run: pnpm run tj-chart

--- a/apps/web/src/app/api/tj-chart/route.ts
+++ b/apps/web/src/app/api/tj-chart/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import createClient from '@/lib/supabase/server';
+import { ApiResponse } from '@/types/apiRoute';
+import { Song } from '@/types/song';
+import { StrType, TjChartResponse } from '@/types/tjChart';
+
+interface ChartRow {
+  rank: number;
+  songs: Song | null;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<ApiResponse<TjChartResponse>>> {
+  try {
+    const supabase = await createClient();
+    const searchParams = request.nextUrl.searchParams;
+
+    const genreParam = searchParams.get('genre') ?? StrType.All;
+    const genre = Object.values(StrType).includes(genreParam as StrType)
+      ? (genreParam as StrType)
+      : StrType.All;
+
+    // 1) 데이터가 존재하는 월 목록 조회
+    const { data: monthRows, error: monthError } = await supabase
+      .from('chart_rankings')
+      .select('chart_month')
+      .order('chart_month', { ascending: false });
+
+    if (monthError) throw monthError;
+
+    const availableMonths = [...new Set((monthRows ?? []).map(row => row.chart_month as string))];
+
+    if (availableMonths.length === 0) {
+      return NextResponse.json({
+        success: true,
+        data: { month: '', genre, availableMonths: [], items: [] },
+      });
+    }
+
+    const monthParam = searchParams.get('month');
+    const targetMonth =
+      monthParam && availableMonths.includes(monthParam) ? monthParam : availableMonths[0];
+
+    // 2) 해당 월 + 장르의 차트 순위 조회 (songs 테이블과 조인)
+    const { data, error } = await supabase
+      .from('chart_rankings')
+      .select('rank, songs(id, title, artist, title_ko, artist_ko, num_tj, num_ky)')
+      .eq('chart_month', targetMonth)
+      .eq('type', genre)
+      .order('rank', { ascending: true })
+      .returns<ChartRow[]>();
+
+    if (error) throw error;
+
+    const items = (data ?? [])
+      .filter((row): row is ChartRow & { songs: Song } => row.songs !== null)
+      .map(row => ({ ...row.songs, rank: row.rank }));
+
+    return NextResponse.json({
+      success: true,
+      data: { month: targetMonth, genre, availableMonths, items },
+    });
+  } catch (error) {
+    console.error('Error in tj-chart API:', error);
+    return NextResponse.json({ success: false, error: 'Failed to get tj chart' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/popular/TjChartRankingList.tsx
+++ b/apps/web/src/app/popular/TjChartRankingList.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { Construction } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import MarqueeText from '@/components/MarqueeText';
+import StaticLoading from '@/components/StaticLoading';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useTjChartQuery } from '@/queries/tjChartQuery';
+import { STR_TYPE_LABEL, StrType } from '@/types/tjChart';
+import { cn } from '@/utils/cn';
+
+const getRankStyle = (rank: number) => {
+  switch (rank) {
+    case 1:
+      return 'bg-amber-500 text-white font-bold';
+    case 2:
+      return 'bg-gray-300 text-white font-bold';
+    case 3:
+      return 'bg-amber-700 text-white font-bold';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+};
+
+const formatMonth = (month: string) => {
+  const [year, m] = month.split('-');
+  return `${year}년 ${Number(m)}월`;
+};
+
+export default function TjChartRankingList() {
+  const [genre, setGenre] = useState<StrType>(StrType.All);
+  const [month, setMonth] = useState<string | undefined>(undefined);
+
+  const { data, isPending, isError } = useTjChartQuery(month, genre);
+
+  useEffect(() => {
+    if (data?.month && !month) {
+      setMonth(data.month);
+    }
+  }, [data?.month, month]);
+
+  if (isPending) {
+    return <StaticLoading />;
+  }
+
+  const availableMonths = data?.availableMonths ?? [];
+  const items = data?.items ?? [];
+
+  return (
+    <Card className="relative flex min-h-0 flex-1 flex-col">
+      <CardHeader className="flex shrink-0 flex-col gap-3 pb-2">
+        <CardTitle className="text-xl">TJ 인기차트</CardTitle>
+
+        <div className="flex gap-2">
+          <Select value={month} onValueChange={setMonth} disabled={availableMonths.length === 0}>
+            <SelectTrigger className="w-[120px]" size="sm">
+              <SelectValue placeholder="월 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableMonths.map(m => (
+                <SelectItem key={m} value={m}>
+                  {formatMonth(m)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={genre} onValueChange={value => setGenre(value as StrType)}>
+            <SelectTrigger className="w-[110px]" size="sm">
+              <SelectValue placeholder="장르 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.values(StrType).map(type => (
+                <SelectItem key={type} value={type}>
+                  {STR_TYPE_LABEL[type]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <CardContent className="pt-0">
+          <div className="space-y-0">
+            {isError || items.length === 0 ? (
+              <div className="flex h-64 flex-col items-center justify-center gap-4">
+                <Construction className="text-muted-foreground h-16 w-16" />
+                <p className="text-muted-foreground text-xl">데이터를 준비중이에요</p>
+              </div>
+            ) : (
+              items.map(item => (
+                <div key={item.id} className={cn('flex gap-4 border-b py-3 last:border-0')}>
+                  <div
+                    className={cn(
+                      'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+                      getRankStyle(item.rank),
+                    )}
+                  >
+                    {item.rank}
+                  </div>
+                  <div className="flex w-full justify-between gap-2">
+                    <div className="w-[140px] shrink-0">
+                      <MarqueeText className="text-sm font-medium">{item.title}</MarqueeText>
+                      {item.title_ko && item.title_ko !== item.title && (
+                        <MarqueeText className="text-muted-foreground text-xs">
+                          {item.title_ko}
+                        </MarqueeText>
+                      )}
+                      <MarqueeText className="text-muted-foreground text-xs">
+                        {item.artist}
+                      </MarqueeText>
+                      {item.artist_ko && item.artist_ko !== item.artist && (
+                        <MarqueeText className="text-muted-foreground/70 text-xs">
+                          {item.artist_ko}
+                        </MarqueeText>
+                      )}
+                    </div>
+
+                    <div>
+                      <div className="flex items-center">
+                        <span className="text-brand-tj mr-1 w-8 text-xs">TJ</span>
+                        <span className="text-sm font-medium">{item.num_tj}</span>
+                      </div>
+                      <div className="flex items-center">
+                        <span className="text-brand-ky mr-1 w-8 text-xs">금영</span>
+                        <span className="text-sm font-medium">{item.num_ky}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </ScrollArea>
+    </Card>
+  );
+}

--- a/apps/web/src/app/popular/page.tsx
+++ b/apps/web/src/app/popular/page.tsx
@@ -1,13 +1,13 @@
-import PopularRankingList from './PopularRankingList';
+import TjChartRankingList from './TjChartRankingList';
 
 export default function PopularPage() {
   return (
     <div className="flex h-full flex-col gap-4">
       <h1 className="shrink-0 text-2xl font-bold">인기 노래</h1>
 
-      {/* 추천 곡 순위 */}
+      {/* TJ 공식 차트 기반 인기 순위 */}
 
-      <PopularRankingList />
+      <TjChartRankingList />
     </div>
   );
 }

--- a/apps/web/src/lib/api/tjChart.ts
+++ b/apps/web/src/lib/api/tjChart.ts
@@ -1,0 +1,12 @@
+import { ApiResponse } from '@/types/apiRoute';
+import { StrType, TjChartResponse } from '@/types/tjChart';
+
+import { instance } from './client';
+
+export async function getTjChart(month?: string, genre?: StrType) {
+  const response = await instance.get<ApiResponse<TjChartResponse>>('/tj-chart', {
+    params: { month, genre },
+  });
+
+  return response.data;
+}

--- a/apps/web/src/queries/tjChartQuery.ts
+++ b/apps/web/src/queries/tjChartQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getTjChart } from '@/lib/api/tjChart';
+import { StrType } from '@/types/tjChart';
+
+export const useTjChartQuery = (month?: string, genre?: StrType) => {
+  return useQuery({
+    queryKey: ['tjChart', month, genre],
+    queryFn: async () => {
+      const response = await getTjChart(month, genre);
+
+      if (!response.success) {
+        return null;
+      }
+      return response.data;
+    },
+  });
+};

--- a/apps/web/src/types/tjChart.ts
+++ b/apps/web/src/types/tjChart.ts
@@ -1,0 +1,44 @@
+import { Song } from './song';
+
+// TJ 공식 차트(topAndHot100) 장르 구분값 (DB 저장용, 영어)
+// 참고: https://www.tjmedia.com/chart/top100
+export enum StrType {
+  All = 'all',
+  Kpop = 'kpop',
+  Pop = 'pop',
+  Jpop = 'jpop',
+  Ballad = 'ballad',
+  Dance = 'dance',
+  Trot = 'trot',
+  Folk = 'folk',
+  Ost = 'ost',
+  RockMetal = 'rock_metal',
+  RapHiphop = 'rap_hiphop',
+  RnbUrban = 'rnb_urban',
+}
+
+export const STR_TYPE_LABEL: Record<StrType, string> = {
+  [StrType.All]: '종합',
+  [StrType.Kpop]: '가요',
+  [StrType.Pop]: 'POP',
+  [StrType.Jpop]: 'JPOP',
+  [StrType.Ballad]: '발라드',
+  [StrType.Dance]: '댄스',
+  [StrType.Trot]: '트로트',
+  [StrType.Folk]: '포크',
+  [StrType.Ost]: 'OST',
+  [StrType.RockMetal]: '락/메탈',
+  [StrType.RapHiphop]: '랩/힙합',
+  [StrType.RnbUrban]: 'R&B/어반',
+};
+
+export interface TjChartRankingSong extends Song {
+  rank: number;
+}
+
+export interface TjChartResponse {
+  month: string;
+  genre: StrType;
+  availableMonths: string[];
+  items: TjChartRankingSong[];
+}

--- a/packages/crawling/package.json
+++ b/packages/crawling/package.json
@@ -15,6 +15,8 @@
     "tag-songs": "tsx src/cron/taggingSongs.ts",
     "trans-jpn": "tsx src/cron/translationJpn.ts",
     "tj-all-number": "tsx src/cron/crawlAllTJSongByNumber.ts",
+    "tj-chart": "tsx src/cron/crawlTjChart.ts",
+    "tj-chart-backfill": "tsx src/cron/crawlTjChartBackfill.ts",
     "lint": "eslint .",
     "test": "vitest run",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""

--- a/packages/crawling/src/assets/tjChartBackfillUnmatched.txt
+++ b/packages/crawling/src/assets/tjChartBackfillUnmatched.txt
@@ -1,0 +1,1166 @@
+2025-01-01	종합(all)	rank=26	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-01-01	종합(all)	rank=34	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-01-01	종합(all)	rank=40	num_tj=91507	포장마차 - 황인욱
+2025-01-01	종합(all)	rank=60	num_tj=34687	안아줘 - 정준일
+2025-01-01	종합(all)	rank=71	num_tj=62438	Tears - 소찬휘
+2025-01-01	종합(all)	rank=86	num_tj=59029	Fantastic Baby - 빅뱅
+2025-01-01	종합(all)	rank=87	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-01-01	가요(kpop)	rank=26	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-01-01	가요(kpop)	rank=34	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-01-01	가요(kpop)	rank=39	num_tj=91507	포장마차 - 황인욱
+2025-01-01	가요(kpop)	rank=59	num_tj=34687	안아줘 - 정준일
+2025-01-01	가요(kpop)	rank=70	num_tj=62438	Tears - 소찬휘
+2025-01-01	가요(kpop)	rank=85	num_tj=59029	Fantastic Baby - 빅뱅
+2025-01-01	가요(kpop)	rank=86	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-01-01	가요(kpop)	rank=100	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-01-01	POP(pop)	rank=7	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-01-01	POP(pop)	rank=11	num_tj=7761	Lemon tree - Fool's Garden
+2025-01-01	POP(pop)	rank=14	num_tj=23190	2002 - Anne-Marie
+2025-01-01	POP(pop)	rank=82	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-01-01	JPOP(jpop)	rank=48	num_tj=25627	雪の華 - 中島美嘉
+2025-01-01	발라드(ballad)	rank=12	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-01-01	발라드(ballad)	rank=20	num_tj=91507	포장마차 - 황인욱
+2025-01-01	발라드(ballad)	rank=53	num_tj=29456	If You - 빅뱅
+2025-01-01	발라드(ballad)	rank=71	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-01-01	발라드(ballad)	rank=85	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-01-01	발라드(ballad)	rank=90	num_tj=98727	너를 만나 - 폴킴
+2025-01-01	댄스(dance)	rank=4	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-01-01	댄스(dance)	rank=8	num_tj=62438	Tears - 소찬휘
+2025-01-01	댄스(dance)	rank=10	num_tj=59029	Fantastic Baby - 빅뱅
+2025-01-01	댄스(dance)	rank=12	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-01-01	댄스(dance)	rank=22	num_tj=59014	맨정신 - 빅뱅
+2025-01-01	댄스(dance)	rank=38	num_tj=34174	예술이야 - 싸이
+2025-01-01	댄스(dance)	rank=46	num_tj=59077	불장난 - 블랙핑크
+2025-01-01	댄스(dance)	rank=50	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-01-01	댄스(dance)	rank=68	num_tj=62258	애상 - 쿨
+2025-01-01	댄스(dance)	rank=74	num_tj=59051	하루하루 - 빅뱅
+2025-01-01	댄스(dance)	rank=75	num_tj=59027	챔피언 - 싸이
+2025-01-01	댄스(dance)	rank=84	num_tj=62370	8282 - 다비치
+2025-01-01	댄스(dance)	rank=87	num_tj=59078	마지막처럼 - 블랙핑크
+2025-01-01	댄스(dance)	rank=98	num_tj=59007	내가 제일 잘 나가 - 2NE1
+2025-01-01	댄스(dance)	rank=100	num_tj=59002	거짓말 - 빅뱅
+2025-01-01	트로트(trot)	rank=85	num_tj=62733	초혼 - 장윤정
+2025-01-01	포크(folk)	rank=12	num_tj=93799	첫사랑 - 백아
+2025-01-01	포크(folk)	rank=22	num_tj=62326	스토커 - 10CM
+2025-01-01	포크(folk)	rank=39	num_tj=62262	애상 - 10CM
+2025-01-01	포크(folk)	rank=47	num_tj=64383	숲 - 최유리
+2025-01-01	포크(folk)	rank=48	num_tj=93773	그라데이션 - 10CM
+2025-01-01	포크(folk)	rank=51	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-01-01	포크(folk)	rank=71	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-01-01	포크(folk)	rank=74	num_tj=62553	봄봄봄 - 로이킴
+2025-01-01	포크(folk)	rank=80	num_tj=62349	봄이좋냐?? - 10CM
+2025-01-01	포크(folk)	rank=88	num_tj=64395	애상 - 이무진
+2025-01-01	포크(folk)	rank=89	num_tj=62116	이등병의 편지 - 김광석
+2025-01-01	포크(folk)	rank=96	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-01-01	OST(ost)	rank=17	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-01-01	OST(ost)	rank=19	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-01-01	OST(ost)	rank=27	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-01-01	OST(ost)	rank=30	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-01-01	OST(ost)	rank=46	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-01-01	OST(ost)	rank=69	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-01-01	OST(ost)	rank=73	num_tj=64375	소나기(선재업고튀어OST) - 이클립스
+2025-01-01	OST(ost)	rank=75	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-01-01	OST(ost)	rank=85	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-01-01	락/메탈(rock_metal)	rank=19	num_tj=34687	안아줘 - 정준일
+2025-01-01	락/메탈(rock_metal)	rank=26	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-01-01	락/메탈(rock_metal)	rank=38	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-01-01	락/메탈(rock_metal)	rank=44	num_tj=53705	노래방에서 - 장범준
+2025-01-01	락/메탈(rock_metal)	rank=46	num_tj=64372	HAPPY - 데이식스
+2025-01-01	락/메탈(rock_metal)	rank=47	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-01-01	락/메탈(rock_metal)	rank=51	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-01-01	락/메탈(rock_metal)	rank=66	num_tj=64306	예뻤어 - 데이식스
+2025-01-01	락/메탈(rock_metal)	rank=75	num_tj=64373	고민중독 - QWER
+2025-01-01	락/메탈(rock_metal)	rank=83	num_tj=64364	Welcome to the Show - 데이식스
+2025-01-01	락/메탈(rock_metal)	rank=87	num_tj=62004	가시 - 버즈
+2025-01-01	락/메탈(rock_metal)	rank=89	num_tj=62325	어디에도 - MC THE MAX
+2025-01-01	락/메탈(rock_metal)	rank=91	num_tj=7761	Lemon tree - Fool's Garden
+2025-01-01	락/메탈(rock_metal)	rank=99	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-01-01	락/메탈(rock_metal)	rank=100	num_tj=62550	형(兄) - 노라조
+2025-01-01	랩/힙합(rap_hiphop)	rank=4	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-01-01	랩/힙합(rap_hiphop)	rank=21	num_tj=29215	Bae Bae - 빅뱅
+2025-01-01	랩/힙합(rap_hiphop)	rank=60	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-01-01	랩/힙합(rap_hiphop)	rank=64	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-01-01	랩/힙합(rap_hiphop)	rank=82	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-01-01	랩/힙합(rap_hiphop)	rank=92	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-01-01	랩/힙합(rap_hiphop)	rank=95	num_tj=62250	외톨이 - 아웃사이더
+2025-01-01	랩/힙합(rap_hiphop)	rank=100	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-01-01	R&B/어반(rnb_urban)	rank=22	num_tj=98524	가을 타나 봐 - 바이브
+2025-01-01	R&B/어반(rnb_urban)	rank=24	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-01-01	R&B/어반(rnb_urban)	rank=41	num_tj=62230	눈, 코, 입 - 태양
+2025-01-01	R&B/어반(rnb_urban)	rank=54	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-01-01	R&B/어반(rnb_urban)	rank=58	num_tj=62030	...사랑했잖아... - 린
+2025-01-01	R&B/어반(rnb_urban)	rank=64	num_tj=62229	보여줄게 - 에일리
+2025-01-01	R&B/어반(rnb_urban)	rank=65	num_tj=59008	눈, 코, 입 - 태양
+2025-01-01	R&B/어반(rnb_urban)	rank=73	num_tj=62222	야생화 - 박효신
+2025-01-01	R&B/어반(rnb_urban)	rank=91	num_tj=62113	그런일은 - 박화요비
+2025-01-01	R&B/어반(rnb_urban)	rank=97	num_tj=62036	연 - 빅마마
+2025-01-01	R&B/어반(rnb_urban)	rank=98	num_tj=62431	Marry Me - 마크툽(MAKTUB),구윤회
+2025-02-01	종합(all)	rank=26	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-02-01	종합(all)	rank=39	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-02-01	종합(all)	rank=47	num_tj=91507	포장마차 - 황인욱
+2025-02-01	종합(all)	rank=58	num_tj=34687	안아줘 - 정준일
+2025-02-01	종합(all)	rank=78	num_tj=62438	Tears - 소찬휘
+2025-02-01	종합(all)	rank=79	num_tj=59029	Fantastic Baby - 빅뱅
+2025-02-01	종합(all)	rank=96	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-02-01	가요(kpop)	rank=26	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-02-01	가요(kpop)	rank=38	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-02-01	가요(kpop)	rank=46	num_tj=91507	포장마차 - 황인욱
+2025-02-01	가요(kpop)	rank=56	num_tj=34687	안아줘 - 정준일
+2025-02-01	가요(kpop)	rank=76	num_tj=62438	Tears - 소찬휘
+2025-02-01	가요(kpop)	rank=77	num_tj=59029	Fantastic Baby - 빅뱅
+2025-02-01	가요(kpop)	rank=94	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-02-01	POP(pop)	rank=7	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-02-01	POP(pop)	rank=10	num_tj=23190	2002 - Anne-Marie
+2025-02-01	POP(pop)	rank=13	num_tj=7761	Lemon tree - Fool's Garden
+2025-02-01	POP(pop)	rank=99	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-02-01	JPOP(jpop)	rank=62	num_tj=25627	雪の華 - 中島美嘉
+2025-02-01	발라드(ballad)	rank=11	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-02-01	발라드(ballad)	rank=23	num_tj=91507	포장마차 - 황인욱
+2025-02-01	발라드(ballad)	rank=53	num_tj=29456	If You - 빅뱅
+2025-02-01	발라드(ballad)	rank=73	num_tj=98888	사랑에 연습이 있었다면 - 임재현(Prod. By 2soo)
+2025-02-01	발라드(ballad)	rank=77	num_tj=98727	너를 만나 - 폴킴
+2025-02-01	발라드(ballad)	rank=81	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-02-01	발라드(ballad)	rank=85	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-02-01	댄스(dance)	rank=6	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-02-01	댄스(dance)	rank=9	num_tj=62438	Tears - 소찬휘
+2025-02-01	댄스(dance)	rank=10	num_tj=59029	Fantastic Baby - 빅뱅
+2025-02-01	댄스(dance)	rank=17	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-02-01	댄스(dance)	rank=19	num_tj=59014	맨정신 - 빅뱅
+2025-02-01	댄스(dance)	rank=43	num_tj=34174	예술이야 - 싸이
+2025-02-01	댄스(dance)	rank=47	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-02-01	댄스(dance)	rank=48	num_tj=59077	불장난 - 블랙핑크
+2025-02-01	댄스(dance)	rank=76	num_tj=62258	애상 - 쿨
+2025-02-01	댄스(dance)	rank=79	num_tj=59051	하루하루 - 빅뱅
+2025-02-01	댄스(dance)	rank=80	num_tj=59027	챔피언 - 싸이
+2025-02-01	댄스(dance)	rank=86	num_tj=62370	8282 - 다비치
+2025-02-01	댄스(dance)	rank=100	num_tj=59078	마지막처럼 - 블랙핑크
+2025-02-01	트로트(trot)	rank=83	num_tj=62733	초혼 - 장윤정
+2025-02-01	포크(folk)	rank=13	num_tj=93799	첫사랑 - 백아
+2025-02-01	포크(folk)	rank=27	num_tj=62326	스토커 - 10CM
+2025-02-01	포크(folk)	rank=36	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-02-01	포크(folk)	rank=44	num_tj=62262	애상 - 10CM
+2025-02-01	포크(folk)	rank=47	num_tj=93773	그라데이션 - 10CM
+2025-02-01	포크(folk)	rank=51	num_tj=64383	숲 - 최유리
+2025-02-01	포크(folk)	rank=54	num_tj=62553	봄봄봄 - 로이킴
+2025-02-01	포크(folk)	rank=68	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-02-01	포크(folk)	rank=69	num_tj=62349	봄이좋냐?? - 10CM
+2025-02-01	포크(folk)	rank=84	num_tj=62116	이등병의 편지 - 김광석
+2025-02-01	포크(folk)	rank=98	num_tj=64395	애상 - 이무진
+2025-02-01	포크(folk)	rank=99	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-02-01	OST(ost)	rank=18	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-02-01	OST(ost)	rank=20	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-02-01	OST(ost)	rank=28	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-02-01	OST(ost)	rank=30	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-02-01	OST(ost)	rank=44	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-02-01	OST(ost)	rank=62	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-02-01	OST(ost)	rank=74	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-02-01	OST(ost)	rank=79	num_tj=64375	소나기(선재업고튀어OST) - 이클립스
+2025-02-01	OST(ost)	rank=80	num_tj=98684	내 생에 아름다운(뷰티인사이드OST) - K.Will
+2025-02-01	OST(ost)	rank=89	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-02-01	락/메탈(rock_metal)	rank=19	num_tj=34687	안아줘 - 정준일
+2025-02-01	락/메탈(rock_metal)	rank=28	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-02-01	락/메탈(rock_metal)	rank=33	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-02-01	락/메탈(rock_metal)	rank=42	num_tj=53705	노래방에서 - 장범준
+2025-02-01	락/메탈(rock_metal)	rank=48	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-02-01	락/메탈(rock_metal)	rank=52	num_tj=64372	HAPPY - 데이식스
+2025-02-01	락/메탈(rock_metal)	rank=60	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-02-01	락/메탈(rock_metal)	rank=79	num_tj=64306	예뻤어 - 데이식스
+2025-02-01	락/메탈(rock_metal)	rank=81	num_tj=64415	내 이름 맑음 - QWER
+2025-02-01	락/메탈(rock_metal)	rank=87	num_tj=64373	고민중독 - QWER
+2025-02-01	락/메탈(rock_metal)	rank=92	num_tj=64364	Welcome to the Show - 데이식스
+2025-02-01	락/메탈(rock_metal)	rank=93	num_tj=62004	가시 - 버즈
+2025-02-01	락/메탈(rock_metal)	rank=96	num_tj=62550	형(兄) - 노라조
+2025-02-01	락/메탈(rock_metal)	rank=99	num_tj=62325	어디에도 - MC THE MAX
+2025-02-01	랩/힙합(rap_hiphop)	rank=7	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-02-01	랩/힙합(rap_hiphop)	rank=10	num_tj=29215	Bae Bae - 빅뱅
+2025-02-01	랩/힙합(rap_hiphop)	rank=61	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-02-01	랩/힙합(rap_hiphop)	rank=63	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-02-01	랩/힙합(rap_hiphop)	rank=78	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-02-01	랩/힙합(rap_hiphop)	rank=85	num_tj=62250	외톨이 - 아웃사이더
+2025-02-01	랩/힙합(rap_hiphop)	rank=93	num_tj=59013	Loser - 빅뱅
+2025-02-01	랩/힙합(rap_hiphop)	rank=95	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-02-01	R&B/어반(rnb_urban)	rank=22	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-02-01	R&B/어반(rnb_urban)	rank=40	num_tj=98524	가을 타나 봐 - 바이브
+2025-02-01	R&B/어반(rnb_urban)	rank=44	num_tj=62230	눈, 코, 입 - 태양
+2025-02-01	R&B/어반(rnb_urban)	rank=62	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-02-01	R&B/어반(rnb_urban)	rank=64	num_tj=62229	보여줄게 - 에일리
+2025-02-01	R&B/어반(rnb_urban)	rank=66	num_tj=62030	...사랑했잖아... - 린
+2025-02-01	R&B/어반(rnb_urban)	rank=69	num_tj=59008	눈, 코, 입 - 태양
+2025-02-01	R&B/어반(rnb_urban)	rank=88	num_tj=62222	야생화 - 박효신
+2025-02-01	R&B/어반(rnb_urban)	rank=96	num_tj=62036	연 - 빅마마
+2025-02-01	R&B/어반(rnb_urban)	rank=98	num_tj=62055	Timeless - SG워너비
+2025-02-01	R&B/어반(rnb_urban)	rank=100	num_tj=62113	그런일은 - 박화요비
+2025-03-01	종합(all)	rank=29	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-03-01	종합(all)	rank=50	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-03-01	종합(all)	rank=51	num_tj=91507	포장마차 - 황인욱
+2025-03-01	종합(all)	rank=66	num_tj=34687	안아줘 - 정준일
+2025-03-01	종합(all)	rank=70	num_tj=62438	Tears - 소찬휘
+2025-03-01	종합(all)	rank=99	num_tj=59029	Fantastic Baby - 빅뱅
+2025-03-01	가요(kpop)	rank=28	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-03-01	가요(kpop)	rank=48	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-03-01	가요(kpop)	rank=49	num_tj=91507	포장마차 - 황인욱
+2025-03-01	가요(kpop)	rank=64	num_tj=34687	안아줘 - 정준일
+2025-03-01	가요(kpop)	rank=68	num_tj=62438	Tears - 소찬휘
+2025-03-01	가요(kpop)	rank=97	num_tj=59029	Fantastic Baby - 빅뱅
+2025-03-01	가요(kpop)	rank=99	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-03-01	POP(pop)	rank=7	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-03-01	POP(pop)	rank=9	num_tj=23190	2002 - Anne-Marie
+2025-03-01	POP(pop)	rank=13	num_tj=7761	Lemon tree - Fool's Garden
+2025-03-01	JPOP(jpop)	rank=74	num_tj=25627	雪の華 - 中島美嘉
+2025-03-01	발라드(ballad)	rank=13	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-03-01	발라드(ballad)	rank=25	num_tj=91507	포장마차 - 황인욱
+2025-03-01	발라드(ballad)	rank=63	num_tj=29456	If You - 빅뱅
+2025-03-01	발라드(ballad)	rank=76	num_tj=98888	사랑에 연습이 있었다면 - 임재현(Prod. By 2soo)
+2025-03-01	발라드(ballad)	rank=79	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-03-01	발라드(ballad)	rank=91	num_tj=98727	너를 만나 - 폴킴
+2025-03-01	발라드(ballad)	rank=92	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-03-01	댄스(dance)	rank=6	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-03-01	댄스(dance)	rank=8	num_tj=62438	Tears - 소찬휘
+2025-03-01	댄스(dance)	rank=12	num_tj=59029	Fantastic Baby - 빅뱅
+2025-03-01	댄스(dance)	rank=13	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-03-01	댄스(dance)	rank=23	num_tj=59014	맨정신 - 빅뱅
+2025-03-01	댄스(dance)	rank=34	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-03-01	댄스(dance)	rank=38	num_tj=34174	예술이야 - 싸이
+2025-03-01	댄스(dance)	rank=55	num_tj=59077	불장난 - 블랙핑크
+2025-03-01	댄스(dance)	rank=74	num_tj=62258	애상 - 쿨
+2025-03-01	댄스(dance)	rank=77	num_tj=62370	8282 - 다비치
+2025-03-01	댄스(dance)	rank=78	num_tj=59027	챔피언 - 싸이
+2025-03-01	댄스(dance)	rank=81	num_tj=59051	하루하루 - 빅뱅
+2025-03-01	댄스(dance)	rank=95	num_tj=59007	내가 제일 잘 나가 - 2NE1
+2025-03-01	트로트(trot)	rank=70	num_tj=62733	초혼 - 장윤정
+2025-03-01	포크(folk)	rank=16	num_tj=93799	첫사랑 - 백아
+2025-03-01	포크(folk)	rank=19	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-03-01	포크(folk)	rank=26	num_tj=62553	봄봄봄 - 로이킴
+2025-03-01	포크(folk)	rank=30	num_tj=62326	스토커 - 10CM
+2025-03-01	포크(folk)	rank=43	num_tj=93773	그라데이션 - 10CM
+2025-03-01	포크(folk)	rank=44	num_tj=62349	봄이좋냐?? - 10CM
+2025-03-01	포크(folk)	rank=46	num_tj=62262	애상 - 10CM
+2025-03-01	포크(folk)	rank=50	num_tj=64383	숲 - 최유리
+2025-03-01	포크(folk)	rank=67	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-03-01	포크(folk)	rank=90	num_tj=62116	이등병의 편지 - 김광석
+2025-03-01	포크(folk)	rank=95	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-03-01	OST(ost)	rank=20	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-03-01	OST(ost)	rank=21	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-03-01	OST(ost)	rank=30	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-03-01	OST(ost)	rank=34	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-03-01	OST(ost)	rank=48	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-03-01	OST(ost)	rank=66	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-03-01	OST(ost)	rank=76	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-03-01	OST(ost)	rank=79	num_tj=98684	내 생에 아름다운(뷰티인사이드OST) - K.Will
+2025-03-01	OST(ost)	rank=86	num_tj=64375	소나기(선재업고튀어OST) - 이클립스
+2025-03-01	OST(ost)	rank=91	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-03-01	락/메탈(rock_metal)	rank=24	num_tj=34687	안아줘 - 정준일
+2025-03-01	락/메탈(rock_metal)	rank=33	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-03-01	락/메탈(rock_metal)	rank=34	num_tj=53705	노래방에서 - 장범준
+2025-03-01	락/메탈(rock_metal)	rank=36	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-03-01	락/메탈(rock_metal)	rank=48	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-03-01	락/메탈(rock_metal)	rank=56	num_tj=64372	HAPPY - 데이식스
+2025-03-01	락/메탈(rock_metal)	rank=66	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-03-01	락/메탈(rock_metal)	rank=82	num_tj=64306	예뻤어 - 데이식스
+2025-03-01	락/메탈(rock_metal)	rank=91	num_tj=62004	가시 - 버즈
+2025-03-01	락/메탈(rock_metal)	rank=94	num_tj=64415	내 이름 맑음 - QWER
+2025-03-01	락/메탈(rock_metal)	rank=95	num_tj=64373	고민중독 - QWER
+2025-03-01	락/메탈(rock_metal)	rank=98	num_tj=62325	어디에도 - MC THE MAX
+2025-03-01	락/메탈(rock_metal)	rank=100	num_tj=62550	형(兄) - 노라조
+2025-03-01	랩/힙합(rap_hiphop)	rank=7	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-03-01	랩/힙합(rap_hiphop)	rank=11	num_tj=29215	Bae Bae - 빅뱅
+2025-03-01	랩/힙합(rap_hiphop)	rank=61	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-03-01	랩/힙합(rap_hiphop)	rank=70	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-03-01	랩/힙합(rap_hiphop)	rank=83	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-03-01	랩/힙합(rap_hiphop)	rank=84	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-03-01	랩/힙합(rap_hiphop)	rank=90	num_tj=62250	외톨이 - 아웃사이더
+2025-03-01	R&B/어반(rnb_urban)	rank=22	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-03-01	R&B/어반(rnb_urban)	rank=36	num_tj=62230	눈, 코, 입 - 태양
+2025-03-01	R&B/어반(rnb_urban)	rank=45	num_tj=98524	가을 타나 봐 - 바이브
+2025-03-01	R&B/어반(rnb_urban)	rank=57	num_tj=62030	...사랑했잖아... - 린
+2025-03-01	R&B/어반(rnb_urban)	rank=61	num_tj=62229	보여줄게 - 에일리
+2025-03-01	R&B/어반(rnb_urban)	rank=71	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-03-01	R&B/어반(rnb_urban)	rank=73	num_tj=59008	눈, 코, 입 - 태양
+2025-03-01	R&B/어반(rnb_urban)	rank=82	num_tj=62055	Timeless - SG워너비
+2025-03-01	R&B/어반(rnb_urban)	rank=84	num_tj=62222	야생화 - 박효신
+2025-03-01	R&B/어반(rnb_urban)	rank=85	num_tj=62350	한숨 - 이하이
+2025-03-01	R&B/어반(rnb_urban)	rank=89	num_tj=62082	..안되나요... - 휘성
+2025-03-01	R&B/어반(rnb_urban)	rank=94	num_tj=62036	연 - 빅마마
+2025-04-01	종합(all)	rank=28	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-04-01	종합(all)	rank=51	num_tj=91507	포장마차 - 황인욱
+2025-04-01	종합(all)	rank=73	num_tj=34687	안아줘 - 정준일
+2025-04-01	종합(all)	rank=75	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-04-01	종합(all)	rank=78	num_tj=62438	Tears - 소찬휘
+2025-04-01	가요(kpop)	rank=27	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-04-01	가요(kpop)	rank=49	num_tj=91507	포장마차 - 황인욱
+2025-04-01	가요(kpop)	rank=71	num_tj=34687	안아줘 - 정준일
+2025-04-01	가요(kpop)	rank=73	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-04-01	가요(kpop)	rank=76	num_tj=62438	Tears - 소찬휘
+2025-04-01	가요(kpop)	rank=97	num_tj=53705	노래방에서 - 장범준
+2025-04-01	가요(kpop)	rank=100	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-04-01	POP(pop)	rank=8	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-04-01	POP(pop)	rank=13	num_tj=23190	2002 - Anne-Marie
+2025-04-01	POP(pop)	rank=22	num_tj=7761	Lemon tree - Fool's Garden
+2025-04-01	POP(pop)	rank=86	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-04-01	JPOP(jpop)	rank=78	num_tj=25627	雪の華 - 中島美嘉
+2025-04-01	발라드(ballad)	rank=14	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-04-01	발라드(ballad)	rank=28	num_tj=91507	포장마차 - 황인욱
+2025-04-01	발라드(ballad)	rank=67	num_tj=29456	If You - 빅뱅
+2025-04-01	발라드(ballad)	rank=78	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-04-01	발라드(ballad)	rank=83	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-04-01	발라드(ballad)	rank=89	num_tj=98888	사랑에 연습이 있었다면 - 임재현(Prod. By 2soo)
+2025-04-01	댄스(dance)	rank=6	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-04-01	댄스(dance)	rank=7	num_tj=62438	Tears - 소찬휘
+2025-04-01	댄스(dance)	rank=9	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-04-01	댄스(dance)	rank=20	num_tj=59029	Fantastic Baby - 빅뱅
+2025-04-01	댄스(dance)	rank=23	num_tj=59014	맨정신 - 빅뱅
+2025-04-01	댄스(dance)	rank=31	num_tj=34174	예술이야 - 싸이
+2025-04-01	댄스(dance)	rank=33	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-04-01	댄스(dance)	rank=64	num_tj=59077	불장난 - 블랙핑크
+2025-04-01	댄스(dance)	rank=68	num_tj=62258	애상 - 쿨
+2025-04-01	댄스(dance)	rank=73	num_tj=62370	8282 - 다비치
+2025-04-01	댄스(dance)	rank=82	num_tj=59027	챔피언 - 싸이
+2025-04-01	댄스(dance)	rank=86	num_tj=59051	하루하루 - 빅뱅
+2025-04-01	댄스(dance)	rank=90	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-04-01	댄스(dance)	rank=93	num_tj=62479	잘못된 만남 - 김건모
+2025-04-01	트로트(trot)	rank=85	num_tj=62733	초혼 - 장윤정
+2025-04-01	포크(folk)	rank=16	num_tj=93799	첫사랑 - 백아
+2025-04-01	포크(folk)	rank=21	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-04-01	포크(folk)	rank=27	num_tj=62553	봄봄봄 - 로이킴
+2025-04-01	포크(folk)	rank=32	num_tj=62326	스토커 - 10CM
+2025-04-01	포크(folk)	rank=39	num_tj=62349	봄이좋냐?? - 10CM
+2025-04-01	포크(folk)	rank=41	num_tj=93773	그라데이션 - 10CM
+2025-04-01	포크(folk)	rank=45	num_tj=62262	애상 - 10CM
+2025-04-01	포크(folk)	rank=54	num_tj=64383	숲 - 최유리
+2025-04-01	포크(folk)	rank=67	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-04-01	포크(folk)	rank=92	num_tj=62116	이등병의 편지 - 김광석
+2025-04-01	포크(folk)	rank=100	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-04-01	OST(ost)	rank=20	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-04-01	OST(ost)	rank=22	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-04-01	OST(ost)	rank=29	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-04-01	OST(ost)	rank=31	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-04-01	OST(ost)	rank=47	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-04-01	OST(ost)	rank=53	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-04-01	OST(ost)	rank=74	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-04-01	OST(ost)	rank=90	num_tj=64375	소나기(선재업고튀어OST) - 이클립스
+2025-04-01	OST(ost)	rank=91	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-04-01	락/메탈(rock_metal)	rank=24	num_tj=34687	안아줘 - 정준일
+2025-04-01	락/메탈(rock_metal)	rank=32	num_tj=53705	노래방에서 - 장범준
+2025-04-01	락/메탈(rock_metal)	rank=35	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-04-01	락/메탈(rock_metal)	rank=37	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-04-01	락/메탈(rock_metal)	rank=53	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-04-01	락/메탈(rock_metal)	rank=59	num_tj=64372	HAPPY - 데이식스
+2025-04-01	락/메탈(rock_metal)	rank=70	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-04-01	락/메탈(rock_metal)	rank=91	num_tj=62004	가시 - 버즈
+2025-04-01	락/메탈(rock_metal)	rank=93	num_tj=64306	예뻤어 - 데이식스
+2025-04-01	랩/힙합(rap_hiphop)	rank=6	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-04-01	랩/힙합(rap_hiphop)	rank=19	num_tj=29215	Bae Bae - 빅뱅
+2025-04-01	랩/힙합(rap_hiphop)	rank=62	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-04-01	랩/힙합(rap_hiphop)	rank=67	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-04-01	랩/힙합(rap_hiphop)	rank=83	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-04-01	랩/힙합(rap_hiphop)	rank=96	num_tj=62250	외톨이 - 아웃사이더
+2025-04-01	R&B/어반(rnb_urban)	rank=23	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-04-01	R&B/어반(rnb_urban)	rank=40	num_tj=62230	눈, 코, 입 - 태양
+2025-04-01	R&B/어반(rnb_urban)	rank=53	num_tj=98524	가을 타나 봐 - 바이브
+2025-04-01	R&B/어반(rnb_urban)	rank=60	num_tj=62030	...사랑했잖아... - 린
+2025-04-01	R&B/어반(rnb_urban)	rank=68	num_tj=62229	보여줄게 - 에일리
+2025-04-01	R&B/어반(rnb_urban)	rank=73	num_tj=62222	야생화 - 박효신
+2025-04-01	R&B/어반(rnb_urban)	rank=74	num_tj=62350	한숨 - 이하이
+2025-04-01	R&B/어반(rnb_urban)	rank=77	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-04-01	R&B/어반(rnb_urban)	rank=80	num_tj=59008	눈, 코, 입 - 태양
+2025-04-01	R&B/어반(rnb_urban)	rank=87	num_tj=62055	Timeless - SG워너비
+2025-04-01	R&B/어반(rnb_urban)	rank=99	num_tj=62036	연 - 빅마마
+2025-05-01	종합(all)	rank=32	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-05-01	종합(all)	rank=53	num_tj=91507	포장마차 - 황인욱
+2025-05-01	종합(all)	rank=64	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-05-01	종합(all)	rank=72	num_tj=62438	Tears - 소찬휘
+2025-05-01	종합(all)	rank=73	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-05-01	종합(all)	rank=79	num_tj=34687	안아줘 - 정준일
+2025-05-01	종합(all)	rank=82	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-05-01	종합(all)	rank=97	num_tj=53705	노래방에서 - 장범준
+2025-05-01	종합(all)	rank=99	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-05-01	가요(kpop)	rank=30	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-05-01	가요(kpop)	rank=51	num_tj=91507	포장마차 - 황인욱
+2025-05-01	가요(kpop)	rank=62	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-05-01	가요(kpop)	rank=70	num_tj=62438	Tears - 소찬휘
+2025-05-01	가요(kpop)	rank=71	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-05-01	가요(kpop)	rank=77	num_tj=34687	안아줘 - 정준일
+2025-05-01	가요(kpop)	rank=79	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-05-01	가요(kpop)	rank=94	num_tj=53705	노래방에서 - 장범준
+2025-05-01	가요(kpop)	rank=96	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-05-01	POP(pop)	rank=7	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-05-01	POP(pop)	rank=10	num_tj=23190	2002 - Anne-Marie
+2025-05-01	POP(pop)	rank=17	num_tj=7761	Lemon tree - Fool's Garden
+2025-05-01	POP(pop)	rank=90	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-05-01	JPOP(jpop)	rank=90	num_tj=25627	雪の華 - 中島美嘉
+2025-05-01	발라드(ballad)	rank=15	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-05-01	발라드(ballad)	rank=27	num_tj=91507	포장마차 - 황인욱
+2025-05-01	발라드(ballad)	rank=74	num_tj=29456	If You - 빅뱅
+2025-05-01	발라드(ballad)	rank=82	num_tj=98888	사랑에 연습이 있었다면 - 임재현(Prod. By 2soo)
+2025-05-01	발라드(ballad)	rank=83	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-05-01	발라드(ballad)	rank=98	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-05-01	댄스(dance)	rank=6	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-05-01	댄스(dance)	rank=7	num_tj=62438	Tears - 소찬휘
+2025-05-01	댄스(dance)	rank=8	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-05-01	댄스(dance)	rank=19	num_tj=59029	Fantastic Baby - 빅뱅
+2025-05-01	댄스(dance)	rank=24	num_tj=59014	맨정신 - 빅뱅
+2025-05-01	댄스(dance)	rank=30	num_tj=34174	예술이야 - 싸이
+2025-05-01	댄스(dance)	rank=42	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-05-01	댄스(dance)	rank=46	num_tj=59077	불장난 - 블랙핑크
+2025-05-01	댄스(dance)	rank=60	num_tj=59027	챔피언 - 싸이
+2025-05-01	댄스(dance)	rank=62	num_tj=62258	애상 - 쿨
+2025-05-01	댄스(dance)	rank=71	num_tj=62370	8282 - 다비치
+2025-05-01	댄스(dance)	rank=82	num_tj=59078	마지막처럼 - 블랙핑크
+2025-05-01	댄스(dance)	rank=97	num_tj=62479	잘못된 만남 - 김건모
+2025-05-01	댄스(dance)	rank=100	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-05-01	트로트(trot)	rank=73	num_tj=62733	초혼 - 장윤정
+2025-05-01	포크(folk)	rank=14	num_tj=93799	첫사랑 - 백아
+2025-05-01	포크(folk)	rank=28	num_tj=62326	스토커 - 10CM
+2025-05-01	포크(folk)	rank=29	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-05-01	포크(folk)	rank=34	num_tj=93773	그라데이션 - 10CM
+2025-05-01	포크(folk)	rank=39	num_tj=62553	봄봄봄 - 로이킴
+2025-05-01	포크(folk)	rank=40	num_tj=62262	애상 - 10CM
+2025-05-01	포크(folk)	rank=50	num_tj=62349	봄이좋냐?? - 10CM
+2025-05-01	포크(folk)	rank=53	num_tj=64383	숲 - 최유리
+2025-05-01	포크(folk)	rank=61	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-05-01	포크(folk)	rank=93	num_tj=62116	이등병의 편지 - 김광석
+2025-05-01	포크(folk)	rank=95	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-05-01	포크(folk)	rank=99	num_tj=64395	애상 - 이무진
+2025-05-01	OST(ost)	rank=16	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-05-01	OST(ost)	rank=18	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-05-01	OST(ost)	rank=32	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-05-01	OST(ost)	rank=37	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-05-01	OST(ost)	rank=42	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-05-01	OST(ost)	rank=57	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-05-01	OST(ost)	rank=74	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-05-01	OST(ost)	rank=83	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-05-01	OST(ost)	rank=94	num_tj=64375	소나기(선재업고튀어OST) - 이클립스
+2025-05-01	락/메탈(rock_metal)	rank=25	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-05-01	락/메탈(rock_metal)	rank=27	num_tj=34687	안아줘 - 정준일
+2025-05-01	락/메탈(rock_metal)	rank=32	num_tj=53705	노래방에서 - 장범준
+2025-05-01	락/메탈(rock_metal)	rank=33	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-05-01	락/메탈(rock_metal)	rank=54	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-05-01	락/메탈(rock_metal)	rank=61	num_tj=64372	HAPPY - 데이식스
+2025-05-01	락/메탈(rock_metal)	rank=69	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-05-01	락/메탈(rock_metal)	rank=91	num_tj=64306	예뻤어 - 데이식스
+2025-05-01	락/메탈(rock_metal)	rank=95	num_tj=99827	옥탑방 - 엔플라잉
+2025-05-01	락/메탈(rock_metal)	rank=96	num_tj=62004	가시 - 버즈
+2025-05-01	락/메탈(rock_metal)	rank=99	num_tj=62325	어디에도 - MC THE MAX
+2025-05-01	랩/힙합(rap_hiphop)	rank=6	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-05-01	랩/힙합(rap_hiphop)	rank=24	num_tj=29215	Bae Bae - 빅뱅
+2025-05-01	랩/힙합(rap_hiphop)	rank=57	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-05-01	랩/힙합(rap_hiphop)	rank=65	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-05-01	랩/힙합(rap_hiphop)	rank=67	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-05-01	랩/힙합(rap_hiphop)	rank=80	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-05-01	랩/힙합(rap_hiphop)	rank=93	num_tj=62250	외톨이 - 아웃사이더
+2025-05-01	랩/힙합(rap_hiphop)	rank=94	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-05-01	랩/힙합(rap_hiphop)	rank=98	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-05-01	R&B/어반(rnb_urban)	rank=20	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-05-01	R&B/어반(rnb_urban)	rank=40	num_tj=98524	가을 타나 봐 - 바이브
+2025-05-01	R&B/어반(rnb_urban)	rank=41	num_tj=62230	눈, 코, 입 - 태양
+2025-05-01	R&B/어반(rnb_urban)	rank=59	num_tj=62229	보여줄게 - 에일리
+2025-05-01	R&B/어반(rnb_urban)	rank=66	num_tj=62030	...사랑했잖아... - 린
+2025-05-01	R&B/어반(rnb_urban)	rank=70	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-05-01	R&B/어반(rnb_urban)	rank=73	num_tj=59008	눈, 코, 입 - 태양
+2025-05-01	R&B/어반(rnb_urban)	rank=83	num_tj=62036	연 - 빅마마
+2025-05-01	R&B/어반(rnb_urban)	rank=86	num_tj=62055	Timeless - SG워너비
+2025-05-01	R&B/어반(rnb_urban)	rank=92	num_tj=62222	야생화 - 박효신
+2025-05-01	R&B/어반(rnb_urban)	rank=97	num_tj=62350	한숨 - 이하이
+2025-06-01	종합(all)	rank=30	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-06-01	종합(all)	rank=58	num_tj=87810	Never Ending Story - IU
+2025-06-01	종합(all)	rank=60	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-06-01	종합(all)	rank=64	num_tj=91507	포장마차 - 황인욱
+2025-06-01	종합(all)	rank=78	num_tj=34687	안아줘 - 정준일
+2025-06-01	종합(all)	rank=79	num_tj=62438	Tears - 소찬휘
+2025-06-01	종합(all)	rank=80	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-06-01	종합(all)	rank=85	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-06-01	가요(kpop)	rank=28	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-06-01	가요(kpop)	rank=56	num_tj=87810	Never Ending Story - IU
+2025-06-01	가요(kpop)	rank=58	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-06-01	가요(kpop)	rank=62	num_tj=91507	포장마차 - 황인욱
+2025-06-01	가요(kpop)	rank=76	num_tj=34687	안아줘 - 정준일
+2025-06-01	가요(kpop)	rank=77	num_tj=62438	Tears - 소찬휘
+2025-06-01	가요(kpop)	rank=78	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-06-01	가요(kpop)	rank=82	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-06-01	POP(pop)	rank=4	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-06-01	POP(pop)	rank=7	num_tj=23190	2002 - Anne-Marie
+2025-06-01	POP(pop)	rank=19	num_tj=7761	Lemon tree - Fool's Garden
+2025-06-01	POP(pop)	rank=89	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-06-01	JPOP(jpop)	rank=91	num_tj=25627	雪の華 - 中島美嘉
+2025-06-01	발라드(ballad)	rank=13	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-06-01	발라드(ballad)	rank=28	num_tj=87810	Never Ending Story - IU
+2025-06-01	발라드(ballad)	rank=31	num_tj=91507	포장마차 - 황인욱
+2025-06-01	발라드(ballad)	rank=80	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-06-01	발라드(ballad)	rank=87	num_tj=64457	모르시나요 - 조째즈(Prod.로코베리)
+2025-06-01	발라드(ballad)	rank=90	num_tj=98888	사랑에 연습이 있었다면 - 임재현(Prod. By 2soo)
+2025-06-01	발라드(ballad)	rank=92	num_tj=29456	If You - 빅뱅
+2025-06-01	댄스(dance)	rank=6	num_tj=62438	Tears - 소찬휘
+2025-06-01	댄스(dance)	rank=7	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-06-01	댄스(dance)	rank=14	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-06-01	댄스(dance)	rank=23	num_tj=34174	예술이야 - 싸이
+2025-06-01	댄스(dance)	rank=24	num_tj=59029	Fantastic Baby - 빅뱅
+2025-06-01	댄스(dance)	rank=25	num_tj=59014	맨정신 - 빅뱅
+2025-06-01	댄스(dance)	rank=38	num_tj=87646	그날이 오면(언젠가는슬기로울전공의생활OST) - 투모로우바이투게더
+2025-06-01	댄스(dance)	rank=44	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-06-01	댄스(dance)	rank=55	num_tj=59027	챔피언 - 싸이
+2025-06-01	댄스(dance)	rank=58	num_tj=62258	애상 - 쿨
+2025-06-01	댄스(dance)	rank=75	num_tj=59077	불장난 - 블랙핑크
+2025-06-01	댄스(dance)	rank=76	num_tj=62370	8282 - 다비치
+2025-06-01	댄스(dance)	rank=81	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-06-01	댄스(dance)	rank=86	num_tj=62479	잘못된 만남 - 김건모
+2025-06-01	트로트(trot)	rank=78	num_tj=62733	초혼 - 장윤정
+2025-06-01	포크(folk)	rank=13	num_tj=93799	첫사랑 - 백아
+2025-06-01	포크(folk)	rank=24	num_tj=62326	스토커 - 10CM
+2025-06-01	포크(folk)	rank=36	num_tj=93773	그라데이션 - 10CM
+2025-06-01	포크(folk)	rank=40	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-06-01	포크(folk)	rank=42	num_tj=62262	애상 - 10CM
+2025-06-01	포크(folk)	rank=50	num_tj=64383	숲 - 최유리
+2025-06-01	포크(folk)	rank=61	num_tj=62553	봄봄봄 - 로이킴
+2025-06-01	포크(folk)	rank=70	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-06-01	포크(folk)	rank=71	num_tj=62349	봄이좋냐?? - 10CM
+2025-06-01	포크(folk)	rank=90	num_tj=62116	이등병의 편지 - 김광석
+2025-06-01	포크(folk)	rank=91	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-06-01	OST(ost)	rank=15	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-06-01	OST(ost)	rank=16	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-06-01	OST(ost)	rank=30	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-06-01	OST(ost)	rank=38	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-06-01	OST(ost)	rank=49	num_tj=87646	그날이 오면(언젠가는슬기로울전공의생활OST) - 투모로우바이투게더
+2025-06-01	OST(ost)	rank=55	num_tj=87718	달리기(언젠가는슬기로울전공의생활OST) - 고윤정,신시아,강유석,한예지
+2025-06-01	OST(ost)	rank=57	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-06-01	OST(ost)	rank=74	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-06-01	OST(ost)	rank=75	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-06-01	OST(ost)	rank=87	num_tj=93771	Butter-Fly(디지몬어드벤처OST) - 전영호
+2025-06-01	OST(ost)	rank=92	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-06-01	OST(ost)	rank=96	num_tj=64375	소나기(선재업고튀어OST) - 이클립스
+2025-06-01	락/메탈(rock_metal)	rank=23	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-06-01	락/메탈(rock_metal)	rank=29	num_tj=34687	안아줘 - 정준일
+2025-06-01	락/메탈(rock_metal)	rank=32	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-06-01	락/메탈(rock_metal)	rank=43	num_tj=53705	노래방에서 - 장범준
+2025-06-01	락/메탈(rock_metal)	rank=55	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-06-01	락/메탈(rock_metal)	rank=60	num_tj=64372	HAPPY - 데이식스
+2025-06-01	락/메탈(rock_metal)	rank=65	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-06-01	락/메탈(rock_metal)	rank=91	num_tj=62004	가시 - 버즈
+2025-06-01	락/메탈(rock_metal)	rank=92	num_tj=87718	달리기(언젠가는슬기로울전공의생활OST) - 고윤정,신시아,강유석,한예지
+2025-06-01	락/메탈(rock_metal)	rank=96	num_tj=64306	예뻤어 - 데이식스
+2025-06-01	락/메탈(rock_metal)	rank=99	num_tj=64415	내 이름 맑음 - QWER
+2025-06-01	락/메탈(rock_metal)	rank=100	num_tj=62550	형(兄) - 노라조
+2025-06-01	랩/힙합(rap_hiphop)	rank=7	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-06-01	랩/힙합(rap_hiphop)	rank=11	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-06-01	랩/힙합(rap_hiphop)	rank=36	num_tj=29215	Bae Bae - 빅뱅
+2025-06-01	랩/힙합(rap_hiphop)	rank=68	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-06-01	랩/힙합(rap_hiphop)	rank=77	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-06-01	랩/힙합(rap_hiphop)	rank=82	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-06-01	랩/힙합(rap_hiphop)	rank=92	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2025-06-01	R&B/어반(rnb_urban)	rank=22	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-06-01	R&B/어반(rnb_urban)	rank=42	num_tj=98524	가을 타나 봐 - 바이브
+2025-06-01	R&B/어반(rnb_urban)	rank=48	num_tj=62230	눈, 코, 입 - 태양
+2025-06-01	R&B/어반(rnb_urban)	rank=61	num_tj=62229	보여줄게 - 에일리
+2025-06-01	R&B/어반(rnb_urban)	rank=70	num_tj=62030	...사랑했잖아... - 린
+2025-06-01	R&B/어반(rnb_urban)	rank=75	num_tj=62036	연 - 빅마마
+2025-06-01	R&B/어반(rnb_urban)	rank=82	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-06-01	R&B/어반(rnb_urban)	rank=84	num_tj=62055	Timeless - SG워너비
+2025-06-01	R&B/어반(rnb_urban)	rank=86	num_tj=87624	Again - 신예영
+2025-06-01	R&B/어반(rnb_urban)	rank=91	num_tj=62222	야생화 - 박효신
+2025-06-01	R&B/어반(rnb_urban)	rank=98	num_tj=62350	한숨 - 이하이
+2025-06-01	R&B/어반(rnb_urban)	rank=100	num_tj=59008	눈, 코, 입 - 태양
+2025-07-01	종합(all)	rank=38	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-07-01	종합(all)	rank=55	num_tj=91507	포장마차 - 황인욱
+2025-07-01	종합(all)	rank=57	num_tj=87810	Never Ending Story - IU
+2025-07-01	종합(all)	rank=65	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-07-01	종합(all)	rank=68	num_tj=62438	Tears - 소찬휘
+2025-07-01	종합(all)	rank=84	num_tj=34687	안아줘 - 정준일
+2025-07-01	종합(all)	rank=87	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-07-01	종합(all)	rank=95	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-07-01	종합(all)	rank=99	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-07-01	가요(kpop)	rank=36	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-07-01	가요(kpop)	rank=53	num_tj=91507	포장마차 - 황인욱
+2025-07-01	가요(kpop)	rank=55	num_tj=87810	Never Ending Story - IU
+2025-07-01	가요(kpop)	rank=63	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-07-01	가요(kpop)	rank=66	num_tj=62438	Tears - 소찬휘
+2025-07-01	가요(kpop)	rank=81	num_tj=34687	안아줘 - 정준일
+2025-07-01	가요(kpop)	rank=84	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-07-01	가요(kpop)	rank=92	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-07-01	가요(kpop)	rank=95	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-07-01	POP(pop)	rank=3	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-07-01	POP(pop)	rank=8	num_tj=23190	2002 - Anne-Marie
+2025-07-01	POP(pop)	rank=18	num_tj=7761	Lemon tree - Fool's Garden
+2025-07-01	POP(pop)	rank=89	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-07-01	발라드(ballad)	rank=14	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-07-01	발라드(ballad)	rank=24	num_tj=91507	포장마차 - 황인욱
+2025-07-01	발라드(ballad)	rank=26	num_tj=87810	Never Ending Story - IU
+2025-07-01	발라드(ballad)	rank=82	num_tj=29456	If You - 빅뱅
+2025-07-01	발라드(ballad)	rank=83	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-07-01	발라드(ballad)	rank=89	num_tj=64457	모르시나요 - 조째즈(Prod.로코베리)
+2025-07-01	발라드(ballad)	rank=91	num_tj=98888	사랑에 연습이 있었다면 - 임재현(Prod. By 2soo)
+2025-07-01	댄스(dance)	rank=8	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-07-01	댄스(dance)	rank=9	num_tj=62438	Tears - 소찬휘
+2025-07-01	댄스(dance)	rank=12	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-07-01	댄스(dance)	rank=20	num_tj=34174	예술이야 - 싸이
+2025-07-01	댄스(dance)	rank=27	num_tj=59029	Fantastic Baby - 빅뱅
+2025-07-01	댄스(dance)	rank=30	num_tj=59014	맨정신 - 빅뱅
+2025-07-01	댄스(dance)	rank=44	num_tj=62258	애상 - 쿨
+2025-07-01	댄스(dance)	rank=46	num_tj=59077	불장난 - 블랙핑크
+2025-07-01	댄스(dance)	rank=65	num_tj=59027	챔피언 - 싸이
+2025-07-01	댄스(dance)	rank=78	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-07-01	댄스(dance)	rank=82	num_tj=59078	마지막처럼 - 블랙핑크
+2025-07-01	댄스(dance)	rank=85	num_tj=62370	8282 - 다비치
+2025-07-01	댄스(dance)	rank=86	num_tj=87646	그날이 오면(언젠가는슬기로울전공의생활OST) - 투모로우바이투게더
+2025-07-01	댄스(dance)	rank=89	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-07-01	트로트(trot)	rank=73	num_tj=62733	초혼 - 장윤정
+2025-07-01	포크(folk)	rank=12	num_tj=93799	첫사랑 - 백아
+2025-07-01	포크(folk)	rank=25	num_tj=62326	스토커 - 10CM
+2025-07-01	포크(folk)	rank=37	num_tj=93773	그라데이션 - 10CM
+2025-07-01	포크(folk)	rank=40	num_tj=62262	애상 - 10CM
+2025-07-01	포크(folk)	rank=41	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-07-01	포크(folk)	rank=50	num_tj=64383	숲 - 최유리
+2025-07-01	포크(folk)	rank=62	num_tj=62553	봄봄봄 - 로이킴
+2025-07-01	포크(folk)	rank=72	num_tj=62349	봄이좋냐?? - 10CM
+2025-07-01	포크(folk)	rank=74	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-07-01	포크(folk)	rank=91	num_tj=62116	이등병의 편지 - 김광석
+2025-07-01	포크(folk)	rank=92	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-07-01	포크(folk)	rank=96	num_tj=64395	애상 - 이무진
+2025-07-01	OST(ost)	rank=16	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-07-01	OST(ost)	rank=21	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-07-01	OST(ost)	rank=32	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-07-01	OST(ost)	rank=34	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-07-01	OST(ost)	rank=67	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-07-01	OST(ost)	rank=83	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-07-01	OST(ost)	rank=87	num_tj=87646	그날이 오면(언젠가는슬기로울전공의생활OST) - 투모로우바이투게더
+2025-07-01	OST(ost)	rank=91	num_tj=62237	All For You(응답하라1997 OST) - 서인국,정은지
+2025-07-01	OST(ost)	rank=95	num_tj=87718	달리기(언젠가는슬기로울전공의생활OST) - 고윤정,신시아,강유석,한예지
+2025-07-01	OST(ost)	rank=100	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-07-01	락/메탈(rock_metal)	rank=28	num_tj=34687	안아줘 - 정준일
+2025-07-01	락/메탈(rock_metal)	rank=29	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-07-01	락/메탈(rock_metal)	rank=33	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-07-01	락/메탈(rock_metal)	rank=48	num_tj=53705	노래방에서 - 장범준
+2025-07-01	락/메탈(rock_metal)	rank=61	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-07-01	락/메탈(rock_metal)	rank=67	num_tj=64372	HAPPY - 데이식스
+2025-07-01	락/메탈(rock_metal)	rank=79	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-07-01	락/메탈(rock_metal)	rank=84	num_tj=62004	가시 - 버즈
+2025-07-01	락/메탈(rock_metal)	rank=93	num_tj=62550	형(兄) - 노라조
+2025-07-01	락/메탈(rock_metal)	rank=94	num_tj=64306	예뻤어 - 데이식스
+2025-07-01	랩/힙합(rap_hiphop)	rank=7	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-07-01	랩/힙합(rap_hiphop)	rank=19	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-07-01	랩/힙합(rap_hiphop)	rank=42	num_tj=29215	Bae Bae - 빅뱅
+2025-07-01	랩/힙합(rap_hiphop)	rank=66	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-07-01	랩/힙합(rap_hiphop)	rank=75	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-07-01	랩/힙합(rap_hiphop)	rank=80	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-07-01	랩/힙합(rap_hiphop)	rank=85	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-07-01	랩/힙합(rap_hiphop)	rank=86	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-07-01	랩/힙합(rap_hiphop)	rank=91	num_tj=62250	외톨이 - 아웃사이더
+2025-07-01	R&B/어반(rnb_urban)	rank=20	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-07-01	R&B/어반(rnb_urban)	rank=33	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2025-07-01	R&B/어반(rnb_urban)	rank=37	num_tj=98524	가을 타나 봐 - 바이브
+2025-07-01	R&B/어반(rnb_urban)	rank=46	num_tj=62230	눈, 코, 입 - 태양
+2025-07-01	R&B/어반(rnb_urban)	rank=63	num_tj=62229	보여줄게 - 에일리
+2025-07-01	R&B/어반(rnb_urban)	rank=68	num_tj=62030	...사랑했잖아... - 린
+2025-07-01	R&B/어반(rnb_urban)	rank=73	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-07-01	R&B/어반(rnb_urban)	rank=85	num_tj=62055	Timeless - SG워너비
+2025-07-01	R&B/어반(rnb_urban)	rank=95	num_tj=59008	눈, 코, 입 - 태양
+2025-07-01	R&B/어반(rnb_urban)	rank=98	num_tj=62222	야생화 - 박효신
+2025-07-01	R&B/어반(rnb_urban)	rank=99	num_tj=62350	한숨 - 이하이
+2025-08-01	종합(all)	rank=33	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-08-01	종합(all)	rank=40	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-08-01	종합(all)	rank=63	num_tj=91507	포장마차 - 황인욱
+2025-08-01	종합(all)	rank=77	num_tj=87810	Never Ending Story - IU
+2025-08-01	종합(all)	rank=79	num_tj=34687	안아줘 - 정준일
+2025-08-01	종합(all)	rank=80	num_tj=62438	Tears - 소찬휘
+2025-08-01	종합(all)	rank=85	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-08-01	가요(kpop)	rank=32	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-08-01	가요(kpop)	rank=38	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-08-01	가요(kpop)	rank=61	num_tj=91507	포장마차 - 황인욱
+2025-08-01	가요(kpop)	rank=74	num_tj=87810	Never Ending Story - IU
+2025-08-01	가요(kpop)	rank=76	num_tj=34687	안아줘 - 정준일
+2025-08-01	가요(kpop)	rank=77	num_tj=62438	Tears - 소찬휘
+2025-08-01	가요(kpop)	rank=82	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-08-01	POP(pop)	rank=3	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-08-01	POP(pop)	rank=9	num_tj=23190	2002 - Anne-Marie
+2025-08-01	POP(pop)	rank=18	num_tj=7761	Lemon tree - Fool's Garden
+2025-08-01	JPOP(jpop)	rank=98	num_tj=25627	雪の華 - 中島美嘉
+2025-08-01	발라드(ballad)	rank=12	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-08-01	발라드(ballad)	rank=29	num_tj=91507	포장마차 - 황인욱
+2025-08-01	발라드(ballad)	rank=37	num_tj=87810	Never Ending Story - IU
+2025-08-01	발라드(ballad)	rank=80	num_tj=64457	모르시나요 - 조째즈(Prod.로코베리)
+2025-08-01	발라드(ballad)	rank=83	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-08-01	발라드(ballad)	rank=88	num_tj=29456	If You - 빅뱅
+2025-08-01	댄스(dance)	rank=5	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-08-01	댄스(dance)	rank=10	num_tj=62438	Tears - 소찬휘
+2025-08-01	댄스(dance)	rank=16	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-08-01	댄스(dance)	rank=19	num_tj=34174	예술이야 - 싸이
+2025-08-01	댄스(dance)	rank=33	num_tj=59029	Fantastic Baby - 빅뱅
+2025-08-01	댄스(dance)	rank=37	num_tj=59014	맨정신 - 빅뱅
+2025-08-01	댄스(dance)	rank=54	num_tj=62258	애상 - 쿨
+2025-08-01	댄스(dance)	rank=60	num_tj=59077	불장난 - 블랙핑크
+2025-08-01	댄스(dance)	rank=66	num_tj=59027	챔피언 - 싸이
+2025-08-01	댄스(dance)	rank=79	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-08-01	댄스(dance)	rank=81	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-08-01	댄스(dance)	rank=82	num_tj=62370	8282 - 다비치
+2025-08-01	댄스(dance)	rank=96	num_tj=62479	잘못된 만남 - 김건모
+2025-08-01	트로트(trot)	rank=69	num_tj=62733	초혼 - 장윤정
+2025-08-01	포크(folk)	rank=15	num_tj=93799	첫사랑 - 백아
+2025-08-01	포크(folk)	rank=26	num_tj=62326	스토커 - 10CM
+2025-08-01	포크(folk)	rank=38	num_tj=93773	그라데이션 - 10CM
+2025-08-01	포크(folk)	rank=41	num_tj=62262	애상 - 10CM
+2025-08-01	포크(folk)	rank=44	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-08-01	포크(folk)	rank=50	num_tj=64383	숲 - 최유리
+2025-08-01	포크(folk)	rank=70	num_tj=62553	봄봄봄 - 로이킴
+2025-08-01	포크(folk)	rank=75	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-08-01	포크(folk)	rank=87	num_tj=62349	봄이좋냐?? - 10CM
+2025-08-01	포크(folk)	rank=89	num_tj=62116	이등병의 편지 - 김광석
+2025-08-01	포크(folk)	rank=97	num_tj=64263	잠깐 시간 될까 - 이무진
+2025-08-01	OST(ost)	rank=11	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-08-01	OST(ost)	rank=19	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-08-01	OST(ost)	rank=35	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-08-01	OST(ost)	rank=39	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-08-01	OST(ost)	rank=67	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-08-01	OST(ost)	rank=85	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-08-01	락/메탈(rock_metal)	rank=26	num_tj=34687	안아줘 - 정준일
+2025-08-01	락/메탈(rock_metal)	rank=28	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-08-01	락/메탈(rock_metal)	rank=36	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-08-01	락/메탈(rock_metal)	rank=45	num_tj=53705	노래방에서 - 장범준
+2025-08-01	락/메탈(rock_metal)	rank=60	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-08-01	락/메탈(rock_metal)	rank=76	num_tj=64372	HAPPY - 데이식스
+2025-08-01	락/메탈(rock_metal)	rank=85	num_tj=62004	가시 - 버즈
+2025-08-01	락/메탈(rock_metal)	rank=92	num_tj=62550	형(兄) - 노라조
+2025-08-01	락/메탈(rock_metal)	rank=93	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-08-01	랩/힙합(rap_hiphop)	rank=9	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-08-01	랩/힙합(rap_hiphop)	rank=22	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-08-01	랩/힙합(rap_hiphop)	rank=54	num_tj=29215	Bae Bae - 빅뱅
+2025-08-01	랩/힙합(rap_hiphop)	rank=65	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-08-01	랩/힙합(rap_hiphop)	rank=77	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-08-01	랩/힙합(rap_hiphop)	rank=78	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-08-01	랩/힙합(rap_hiphop)	rank=89	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-08-01	랩/힙합(rap_hiphop)	rank=96	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2025-08-01	랩/힙합(rap_hiphop)	rank=97	num_tj=62250	외톨이 - 아웃사이더
+2025-08-01	랩/힙합(rap_hiphop)	rank=99	num_tj=98596	시간이 들겠지 - 로꼬(Feat.콜드)
+2025-08-01	R&B/어반(rnb_urban)	rank=20	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-08-01	R&B/어반(rnb_urban)	rank=30	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2025-08-01	R&B/어반(rnb_urban)	rank=33	num_tj=98524	가을 타나 봐 - 바이브
+2025-08-01	R&B/어반(rnb_urban)	rank=58	num_tj=62230	눈, 코, 입 - 태양
+2025-08-01	R&B/어반(rnb_urban)	rank=67	num_tj=62229	보여줄게 - 에일리
+2025-08-01	R&B/어반(rnb_urban)	rank=71	num_tj=62030	...사랑했잖아... - 린
+2025-08-01	R&B/어반(rnb_urban)	rank=79	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-08-01	R&B/어반(rnb_urban)	rank=87	num_tj=62055	Timeless - SG워너비
+2025-08-01	R&B/어반(rnb_urban)	rank=97	num_tj=62350	한숨 - 이하이
+2025-08-01	R&B/어반(rnb_urban)	rank=99	num_tj=62222	야생화 - 박효신
+2025-09-01	종합(all)	rank=29	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-09-01	종합(all)	rank=51	num_tj=98524	가을 타나 봐 - 바이브
+2025-09-01	종합(all)	rank=61	num_tj=34687	안아줘 - 정준일
+2025-09-01	종합(all)	rank=67	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-09-01	종합(all)	rank=68	num_tj=91507	포장마차 - 황인욱
+2025-09-01	종합(all)	rank=95	num_tj=62438	Tears - 소찬휘
+2025-09-01	가요(kpop)	rank=26	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-09-01	가요(kpop)	rank=48	num_tj=98524	가을 타나 봐 - 바이브
+2025-09-01	가요(kpop)	rank=58	num_tj=34687	안아줘 - 정준일
+2025-09-01	가요(kpop)	rank=63	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-09-01	가요(kpop)	rank=64	num_tj=91507	포장마차 - 황인욱
+2025-09-01	가요(kpop)	rank=90	num_tj=62438	Tears - 소찬휘
+2025-09-01	가요(kpop)	rank=100	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-09-01	POP(pop)	rank=4	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-09-01	POP(pop)	rank=8	num_tj=23190	2002 - Anne-Marie
+2025-09-01	POP(pop)	rank=23	num_tj=7761	Lemon tree - Fool's Garden
+2025-09-01	JPOP(jpop)	rank=96	num_tj=25627	雪の華 - 中島美嘉
+2025-09-01	발라드(ballad)	rank=14	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-09-01	발라드(ballad)	rank=32	num_tj=91507	포장마차 - 황인욱
+2025-09-01	발라드(ballad)	rank=54	num_tj=87810	Never Ending Story - IU
+2025-09-01	발라드(ballad)	rank=89	num_tj=98499	이별하러 가는 길 - 임한별
+2025-09-01	발라드(ballad)	rank=91	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-09-01	발라드(ballad)	rank=93	num_tj=64457	모르시나요 - 조째즈(Prod.로코베리)
+2025-09-01	발라드(ballad)	rank=97	num_tj=29456	If You - 빅뱅
+2025-09-01	댄스(dance)	rank=6	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-09-01	댄스(dance)	rank=9	num_tj=62438	Tears - 소찬휘
+2025-09-01	댄스(dance)	rank=16	num_tj=34174	예술이야 - 싸이
+2025-09-01	댄스(dance)	rank=19	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-09-01	댄스(dance)	rank=20	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-09-01	댄스(dance)	rank=26	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-09-01	댄스(dance)	rank=38	num_tj=59014	맨정신 - 빅뱅
+2025-09-01	댄스(dance)	rank=40	num_tj=59029	Fantastic Baby - 빅뱅
+2025-09-01	댄스(dance)	rank=62	num_tj=62258	애상 - 쿨
+2025-09-01	댄스(dance)	rank=66	num_tj=59077	불장난 - 블랙핑크
+2025-09-01	댄스(dance)	rank=79	num_tj=59027	챔피언 - 싸이
+2025-09-01	댄스(dance)	rank=80	num_tj=62370	8282 - 다비치
+2025-09-01	댄스(dance)	rank=82	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-09-01	댄스(dance)	rank=84	num_tj=62479	잘못된 만남 - 김건모
+2025-09-01	댄스(dance)	rank=98	num_tj=64435	APT. - 로제(ROSE),Bruno Mars
+2025-09-01	트로트(trot)	rank=68	num_tj=62733	초혼 - 장윤정
+2025-09-01	포크(folk)	rank=15	num_tj=93799	첫사랑 - 백아
+2025-09-01	포크(folk)	rank=26	num_tj=62326	스토커 - 10CM
+2025-09-01	포크(folk)	rank=35	num_tj=64383	숲 - 최유리
+2025-09-01	포크(folk)	rank=45	num_tj=93773	그라데이션 - 10CM
+2025-09-01	포크(folk)	rank=49	num_tj=62262	애상 - 10CM
+2025-09-01	포크(folk)	rank=53	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-09-01	포크(folk)	rank=77	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-09-01	포크(folk)	rank=80	num_tj=62553	봄봄봄 - 로이킴
+2025-09-01	포크(folk)	rank=95	num_tj=62116	이등병의 편지 - 김광석
+2025-09-01	포크(folk)	rank=97	num_tj=62349	봄이좋냐?? - 10CM
+2025-09-01	OST(ost)	rank=17	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-09-01	OST(ost)	rank=25	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-09-01	OST(ost)	rank=36	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-09-01	OST(ost)	rank=38	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-09-01	OST(ost)	rank=45	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-09-01	OST(ost)	rank=46	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-09-01	OST(ost)	rank=62	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-09-01	OST(ost)	rank=85	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-09-01	락/메탈(rock_metal)	rank=21	num_tj=34687	안아줘 - 정준일
+2025-09-01	락/메탈(rock_metal)	rank=32	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-09-01	락/메탈(rock_metal)	rank=37	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-09-01	락/메탈(rock_metal)	rank=44	num_tj=53705	노래방에서 - 장범준
+2025-09-01	락/메탈(rock_metal)	rank=55	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-09-01	락/메탈(rock_metal)	rank=81	num_tj=64372	HAPPY - 데이식스
+2025-09-01	락/메탈(rock_metal)	rank=85	num_tj=62004	가시 - 버즈
+2025-09-01	락/메탈(rock_metal)	rank=89	num_tj=62550	형(兄) - 노라조
+2025-09-01	랩/힙합(rap_hiphop)	rank=14	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-09-01	랩/힙합(rap_hiphop)	rank=48	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-09-01	랩/힙합(rap_hiphop)	rank=50	num_tj=98596	시간이 들겠지 - 로꼬(Feat.콜드)
+2025-09-01	랩/힙합(rap_hiphop)	rank=61	num_tj=29215	Bae Bae - 빅뱅
+2025-09-01	랩/힙합(rap_hiphop)	rank=62	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-09-01	랩/힙합(rap_hiphop)	rank=65	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-09-01	랩/힙합(rap_hiphop)	rank=80	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-09-01	랩/힙합(rap_hiphop)	rank=90	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2025-09-01	랩/힙합(rap_hiphop)	rank=96	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-09-01	R&B/어반(rnb_urban)	rank=4	num_tj=98524	가을 타나 봐 - 바이브
+2025-09-01	R&B/어반(rnb_urban)	rank=22	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-09-01	R&B/어반(rnb_urban)	rank=29	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2025-09-01	R&B/어반(rnb_urban)	rank=64	num_tj=62350	한숨 - 이하이
+2025-09-01	R&B/어반(rnb_urban)	rank=67	num_tj=62230	눈, 코, 입 - 태양
+2025-09-01	R&B/어반(rnb_urban)	rank=73	num_tj=62030	...사랑했잖아... - 린
+2025-09-01	R&B/어반(rnb_urban)	rank=83	num_tj=62229	보여줄게 - 에일리
+2025-09-01	R&B/어반(rnb_urban)	rank=85	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-09-01	R&B/어반(rnb_urban)	rank=90	num_tj=62055	Timeless - SG워너비
+2025-09-01	R&B/어반(rnb_urban)	rank=100	num_tj=62222	야생화 - 박효신
+2025-10-01	종합(all)	rank=9	num_tj=98524	가을 타나 봐 - 바이브
+2025-10-01	종합(all)	rank=22	num_tj=98499	이별하러 가는 길 - 임한별
+2025-10-01	종합(all)	rank=35	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-10-01	종합(all)	rank=59	num_tj=34687	안아줘 - 정준일
+2025-10-01	종합(all)	rank=62	num_tj=91507	포장마차 - 황인욱
+2025-10-01	종합(all)	rank=85	num_tj=62438	Tears - 소찬휘
+2025-10-01	가요(kpop)	rank=9	num_tj=98524	가을 타나 봐 - 바이브
+2025-10-01	가요(kpop)	rank=21	num_tj=98499	이별하러 가는 길 - 임한별
+2025-10-01	가요(kpop)	rank=32	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-10-01	가요(kpop)	rank=56	num_tj=34687	안아줘 - 정준일
+2025-10-01	가요(kpop)	rank=59	num_tj=91507	포장마차 - 황인욱
+2025-10-01	가요(kpop)	rank=79	num_tj=62438	Tears - 소찬휘
+2025-10-01	가요(kpop)	rank=96	num_tj=87810	Never Ending Story - IU
+2025-10-01	POP(pop)	rank=4	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-10-01	POP(pop)	rank=8	num_tj=23190	2002 - Anne-Marie
+2025-10-01	POP(pop)	rank=20	num_tj=7761	Lemon tree - Fool's Garden
+2025-10-01	POP(pop)	rank=36	num_tj=23362	A Whole New World(Aladdin OST) - ZAYN,Zhavia Ward
+2025-10-01	JPOP(jpop)	rank=98	num_tj=25627	雪の華 - 中島美嘉
+2025-10-01	발라드(ballad)	rank=10	num_tj=98499	이별하러 가는 길 - 임한별
+2025-10-01	발라드(ballad)	rank=17	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-10-01	발라드(ballad)	rank=32	num_tj=91507	포장마차 - 황인욱
+2025-10-01	발라드(ballad)	rank=50	num_tj=87810	Never Ending Story - IU
+2025-10-01	발라드(ballad)	rank=92	num_tj=29456	If You - 빅뱅
+2025-10-01	발라드(ballad)	rank=94	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-10-01	댄스(dance)	rank=8	num_tj=62438	Tears - 소찬휘
+2025-10-01	댄스(dance)	rank=10	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-10-01	댄스(dance)	rank=13	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-10-01	댄스(dance)	rank=16	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-10-01	댄스(dance)	rank=19	num_tj=34174	예술이야 - 싸이
+2025-10-01	댄스(dance)	rank=26	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-10-01	댄스(dance)	rank=31	num_tj=59029	Fantastic Baby - 빅뱅
+2025-10-01	댄스(dance)	rank=35	num_tj=59014	맨정신 - 빅뱅
+2025-10-01	댄스(dance)	rank=57	num_tj=59077	불장난 - 블랙핑크
+2025-10-01	댄스(dance)	rank=59	num_tj=62258	애상 - 쿨
+2025-10-01	댄스(dance)	rank=82	num_tj=59027	챔피언 - 싸이
+2025-10-01	댄스(dance)	rank=85	num_tj=62370	8282 - 다비치
+2025-10-01	댄스(dance)	rank=89	num_tj=62479	잘못된 만남 - 김건모
+2025-10-01	댄스(dance)	rank=97	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-10-01	댄스(dance)	rank=99	num_tj=59078	마지막처럼 - 블랙핑크
+2025-10-01	트로트(trot)	rank=75	num_tj=62733	초혼 - 장윤정
+2025-10-01	포크(folk)	rank=13	num_tj=93799	첫사랑 - 백아
+2025-10-01	포크(folk)	rank=25	num_tj=62326	스토커 - 10CM
+2025-10-01	포크(folk)	rank=34	num_tj=64383	숲 - 최유리
+2025-10-01	포크(folk)	rank=48	num_tj=62262	애상 - 10CM
+2025-10-01	포크(folk)	rank=49	num_tj=93773	그라데이션 - 10CM
+2025-10-01	포크(folk)	rank=55	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-10-01	포크(folk)	rank=75	num_tj=62553	봄봄봄 - 로이킴
+2025-10-01	포크(folk)	rank=83	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-10-01	포크(folk)	rank=90	num_tj=62349	봄이좋냐?? - 10CM
+2025-10-01	포크(folk)	rank=91	num_tj=62116	이등병의 편지 - 김광석
+2025-10-01	OST(ost)	rank=27	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-10-01	OST(ost)	rank=28	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-10-01	OST(ost)	rank=30	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-10-01	OST(ost)	rank=40	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-10-01	OST(ost)	rank=43	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-10-01	OST(ost)	rank=44	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-10-01	OST(ost)	rank=65	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-10-01	OST(ost)	rank=75	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-10-01	OST(ost)	rank=77	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-10-01	락/메탈(rock_metal)	rank=21	num_tj=34687	안아줘 - 정준일
+2025-10-01	락/메탈(rock_metal)	rank=35	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-10-01	락/메탈(rock_metal)	rank=38	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-10-01	락/메탈(rock_metal)	rank=41	num_tj=53705	노래방에서 - 장범준
+2025-10-01	락/메탈(rock_metal)	rank=64	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-10-01	락/메탈(rock_metal)	rank=78	num_tj=64372	HAPPY - 데이식스
+2025-10-01	락/메탈(rock_metal)	rank=86	num_tj=62004	가시 - 버즈
+2025-10-01	락/메탈(rock_metal)	rank=96	num_tj=64304	한 페이지가 될 수 있게 - 데이식스
+2025-10-01	랩/힙합(rap_hiphop)	rank=14	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-10-01	랩/힙합(rap_hiphop)	rank=44	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-10-01	랩/힙합(rap_hiphop)	rank=45	num_tj=98596	시간이 들겠지 - 로꼬(Feat.콜드)
+2025-10-01	랩/힙합(rap_hiphop)	rank=59	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-10-01	랩/힙합(rap_hiphop)	rank=64	num_tj=29215	Bae Bae - 빅뱅
+2025-10-01	랩/힙합(rap_hiphop)	rank=66	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-10-01	랩/힙합(rap_hiphop)	rank=87	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-10-01	랩/힙합(rap_hiphop)	rank=89	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-10-01	랩/힙합(rap_hiphop)	rank=97	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2025-10-01	랩/힙합(rap_hiphop)	rank=100	num_tj=62250	외톨이 - 아웃사이더
+2025-10-01	R&B/어반(rnb_urban)	rank=2	num_tj=98524	가을 타나 봐 - 바이브
+2025-10-01	R&B/어반(rnb_urban)	rank=21	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-10-01	R&B/어반(rnb_urban)	rank=37	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2025-10-01	R&B/어반(rnb_urban)	rank=63	num_tj=62230	눈, 코, 입 - 태양
+2025-10-01	R&B/어반(rnb_urban)	rank=72	num_tj=62350	한숨 - 이하이
+2025-10-01	R&B/어반(rnb_urban)	rank=78	num_tj=62030	...사랑했잖아... - 린
+2025-10-01	R&B/어반(rnb_urban)	rank=80	num_tj=23362	A Whole New World(Aladdin OST) - ZAYN,Zhavia Ward
+2025-10-01	R&B/어반(rnb_urban)	rank=81	num_tj=62229	보여줄게 - 에일리
+2025-10-01	R&B/어반(rnb_urban)	rank=85	num_tj=62055	Timeless - SG워너비
+2025-10-01	R&B/어반(rnb_urban)	rank=88	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-11-01	종합(all)	rank=26	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-11-01	종합(all)	rank=35	num_tj=98499	이별하러 가는 길 - 임한별
+2025-11-01	종합(all)	rank=41	num_tj=98524	가을 타나 봐 - 바이브
+2025-11-01	종합(all)	rank=60	num_tj=91507	포장마차 - 황인욱
+2025-11-01	종합(all)	rank=64	num_tj=34687	안아줘 - 정준일
+2025-11-01	종합(all)	rank=90	num_tj=62438	Tears - 소찬휘
+2025-11-01	가요(kpop)	rank=24	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-11-01	가요(kpop)	rank=32	num_tj=98499	이별하러 가는 길 - 임한별
+2025-11-01	가요(kpop)	rank=36	num_tj=98524	가을 타나 봐 - 바이브
+2025-11-01	가요(kpop)	rank=55	num_tj=91507	포장마차 - 황인욱
+2025-11-01	가요(kpop)	rank=59	num_tj=34687	안아줘 - 정준일
+2025-11-01	가요(kpop)	rank=83	num_tj=62438	Tears - 소찬휘
+2025-11-01	POP(pop)	rank=8	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-11-01	POP(pop)	rank=16	num_tj=23190	2002 - Anne-Marie
+2025-11-01	POP(pop)	rank=22	num_tj=7761	Lemon tree - Fool's Garden
+2025-11-01	POP(pop)	rank=36	num_tj=23362	A Whole New World(Aladdin OST) - ZAYN,Zhavia Ward
+2025-11-01	발라드(ballad)	rank=12	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-11-01	발라드(ballad)	rank=17	num_tj=98499	이별하러 가는 길 - 임한별
+2025-11-01	발라드(ballad)	rank=30	num_tj=91507	포장마차 - 황인욱
+2025-11-01	발라드(ballad)	rank=70	num_tj=87810	Never Ending Story - IU
+2025-11-01	발라드(ballad)	rank=90	num_tj=98727	너를 만나 - 폴킴
+2025-11-01	발라드(ballad)	rank=94	num_tj=29456	If You - 빅뱅
+2025-11-01	댄스(dance)	rank=5	num_tj=62438	Tears - 소찬휘
+2025-11-01	댄스(dance)	rank=14	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-11-01	댄스(dance)	rank=15	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-11-01	댄스(dance)	rank=19	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-11-01	댄스(dance)	rank=22	num_tj=34174	예술이야 - 싸이
+2025-11-01	댄스(dance)	rank=27	num_tj=59014	맨정신 - 빅뱅
+2025-11-01	댄스(dance)	rank=29	num_tj=59029	Fantastic Baby - 빅뱅
+2025-11-01	댄스(dance)	rank=42	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-11-01	댄스(dance)	rank=57	num_tj=59077	불장난 - 블랙핑크
+2025-11-01	댄스(dance)	rank=65	num_tj=62258	애상 - 쿨
+2025-11-01	댄스(dance)	rank=78	num_tj=59027	챔피언 - 싸이
+2025-11-01	댄스(dance)	rank=81	num_tj=62370	8282 - 다비치
+2025-11-01	댄스(dance)	rank=95	num_tj=62479	잘못된 만남 - 김건모
+2025-11-01	댄스(dance)	rank=96	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-11-01	댄스(dance)	rank=99	num_tj=59078	마지막처럼 - 블랙핑크
+2025-11-01	트로트(trot)	rank=81	num_tj=62733	초혼 - 장윤정
+2025-11-01	포크(folk)	rank=15	num_tj=93799	첫사랑 - 백아
+2025-11-01	포크(folk)	rank=30	num_tj=62326	스토커 - 10CM
+2025-11-01	포크(folk)	rank=47	num_tj=64383	숲 - 최유리
+2025-11-01	포크(folk)	rank=52	num_tj=62262	애상 - 10CM
+2025-11-01	포크(folk)	rank=53	num_tj=93773	그라데이션 - 10CM
+2025-11-01	포크(folk)	rank=57	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-11-01	포크(folk)	rank=76	num_tj=62553	봄봄봄 - 로이킴
+2025-11-01	포크(folk)	rank=88	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-11-01	포크(folk)	rank=95	num_tj=62116	이등병의 편지 - 김광석
+2025-11-01	OST(ost)	rank=27	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-11-01	OST(ost)	rank=31	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-11-01	OST(ost)	rank=39	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-11-01	OST(ost)	rank=46	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-11-01	OST(ost)	rank=47	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-11-01	OST(ost)	rank=54	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-11-01	OST(ost)	rank=55	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-11-01	OST(ost)	rank=70	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-11-01	OST(ost)	rank=71	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-11-01	OST(ost)	rank=98	num_tj=62233	나였으면(황태자의첫사랑OST) - 나윤권
+2025-11-01	락/메탈(rock_metal)	rank=22	num_tj=34687	안아줘 - 정준일
+2025-11-01	락/메탈(rock_metal)	rank=36	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-11-01	락/메탈(rock_metal)	rank=37	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-11-01	락/메탈(rock_metal)	rank=39	num_tj=53705	노래방에서 - 장범준
+2025-11-01	락/메탈(rock_metal)	rank=80	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-11-01	락/메탈(rock_metal)	rank=86	num_tj=62004	가시 - 버즈
+2025-11-01	락/메탈(rock_metal)	rank=91	num_tj=64372	HAPPY - 데이식스
+2025-11-01	락/메탈(rock_metal)	rank=96	num_tj=62550	형(兄) - 노라조
+2025-11-01	락/메탈(rock_metal)	rank=99	num_tj=64573	사랑하게 될 거야 - 한로로
+2025-11-01	랩/힙합(rap_hiphop)	rank=11	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-11-01	랩/힙합(rap_hiphop)	rank=42	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-11-01	랩/힙합(rap_hiphop)	rank=55	num_tj=98596	시간이 들겠지 - 로꼬(Feat.콜드)
+2025-11-01	랩/힙합(rap_hiphop)	rank=63	num_tj=29215	Bae Bae - 빅뱅
+2025-11-01	랩/힙합(rap_hiphop)	rank=69	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-11-01	랩/힙합(rap_hiphop)	rank=84	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-11-01	랩/힙합(rap_hiphop)	rank=87	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-11-01	랩/힙합(rap_hiphop)	rank=93	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-11-01	랩/힙합(rap_hiphop)	rank=97	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2025-11-01	랩/힙합(rap_hiphop)	rank=100	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-11-01	R&B/어반(rnb_urban)	rank=2	num_tj=98524	가을 타나 봐 - 바이브
+2025-11-01	R&B/어반(rnb_urban)	rank=24	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-11-01	R&B/어반(rnb_urban)	rank=44	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2025-11-01	R&B/어반(rnb_urban)	rank=75	num_tj=23362	A Whole New World(Aladdin OST) - ZAYN,Zhavia Ward
+2025-11-01	R&B/어반(rnb_urban)	rank=76	num_tj=62230	눈, 코, 입 - 태양
+2025-11-01	R&B/어반(rnb_urban)	rank=84	num_tj=62030	...사랑했잖아... - 린
+2025-11-01	R&B/어반(rnb_urban)	rank=86	num_tj=62229	보여줄게 - 에일리
+2025-11-01	R&B/어반(rnb_urban)	rank=90	num_tj=62055	Timeless - SG워너비
+2025-11-01	R&B/어반(rnb_urban)	rank=92	num_tj=62350	한숨 - 이하이
+2025-11-01	R&B/어반(rnb_urban)	rank=94	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-12-01	종합(all)	rank=34	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-12-01	종합(all)	rank=41	num_tj=98499	이별하러 가는 길 - 임한별
+2025-12-01	종합(all)	rank=59	num_tj=91507	포장마차 - 황인욱
+2025-12-01	종합(all)	rank=64	num_tj=34687	안아줘 - 정준일
+2025-12-01	종합(all)	rank=84	num_tj=62438	Tears - 소찬휘
+2025-12-01	가요(kpop)	rank=31	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-12-01	가요(kpop)	rank=36	num_tj=98499	이별하러 가는 길 - 임한별
+2025-12-01	가요(kpop)	rank=51	num_tj=91507	포장마차 - 황인욱
+2025-12-01	가요(kpop)	rank=56	num_tj=34687	안아줘 - 정준일
+2025-12-01	가요(kpop)	rank=74	num_tj=62438	Tears - 소찬휘
+2025-12-01	POP(pop)	rank=13	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-12-01	POP(pop)	rank=17	num_tj=23190	2002 - Anne-Marie
+2025-12-01	POP(pop)	rank=23	num_tj=7761	Lemon tree - Fool's Garden
+2025-12-01	POP(pop)	rank=72	num_tj=62425	Last Christmas - Wham
+2025-12-01	POP(pop)	rank=75	num_tj=62148	All I Want For Christmas Is You - Mariah Carey
+2025-12-01	POP(pop)	rank=91	num_tj=62243	Let It Go(Frozen(겨울왕국) OST) - Idina Menzel
+2025-12-01	JPOP(jpop)	rank=96	num_tj=25627	雪の華 - 中島美嘉
+2025-12-01	발라드(ballad)	rank=16	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2025-12-01	발라드(ballad)	rank=19	num_tj=98499	이별하러 가는 길 - 임한별
+2025-12-01	발라드(ballad)	rank=29	num_tj=91507	포장마차 - 황인욱
+2025-12-01	발라드(ballad)	rank=77	num_tj=29456	If You - 빅뱅
+2025-12-01	발라드(ballad)	rank=98	num_tj=98727	너를 만나 - 폴킴
+2025-12-01	댄스(dance)	rank=4	num_tj=62438	Tears - 소찬휘
+2025-12-01	댄스(dance)	rank=10	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2025-12-01	댄스(dance)	rank=16	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-12-01	댄스(dance)	rank=22	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-12-01	댄스(dance)	rank=24	num_tj=34174	예술이야 - 싸이
+2025-12-01	댄스(dance)	rank=29	num_tj=59014	맨정신 - 빅뱅
+2025-12-01	댄스(dance)	rank=31	num_tj=59029	Fantastic Baby - 빅뱅
+2025-12-01	댄스(dance)	rank=49	num_tj=59077	불장난 - 블랙핑크
+2025-12-01	댄스(dance)	rank=62	num_tj=59027	챔피언 - 싸이
+2025-12-01	댄스(dance)	rank=64	num_tj=62258	애상 - 쿨
+2025-12-01	댄스(dance)	rank=71	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-12-01	댄스(dance)	rank=79	num_tj=62370	8282 - 다비치
+2025-12-01	댄스(dance)	rank=86	num_tj=62507	슬퍼지려 하기전에 - 쿨
+2025-12-01	댄스(dance)	rank=88	num_tj=62479	잘못된 만남 - 김건모
+2025-12-01	댄스(dance)	rank=94	num_tj=59078	마지막처럼 - 블랙핑크
+2025-12-01	트로트(trot)	rank=91	num_tj=62733	초혼 - 장윤정
+2025-12-01	포크(folk)	rank=15	num_tj=93799	첫사랑 - 백아
+2025-12-01	포크(folk)	rank=31	num_tj=62326	스토커 - 10CM
+2025-12-01	포크(folk)	rank=48	num_tj=62262	애상 - 10CM
+2025-12-01	포크(folk)	rank=59	num_tj=93773	그라데이션 - 10CM
+2025-12-01	포크(folk)	rank=60	num_tj=64383	숲 - 최유리
+2025-12-01	포크(folk)	rank=63	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2025-12-01	포크(folk)	rank=78	num_tj=62553	봄봄봄 - 로이킴
+2025-12-01	포크(folk)	rank=85	num_tj=62116	이등병의 편지 - 김광석
+2025-12-01	포크(folk)	rank=94	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2025-12-01	OST(ost)	rank=26	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-12-01	OST(ost)	rank=35	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2025-12-01	OST(ost)	rank=39	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2025-12-01	OST(ost)	rank=49	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2025-12-01	OST(ost)	rank=58	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2025-12-01	OST(ost)	rank=61	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-12-01	OST(ost)	rank=65	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-12-01	OST(ost)	rank=79	num_tj=96209	있잖아(연애플레이리스트2 OST) - 폴킴
+2025-12-01	OST(ost)	rank=80	num_tj=98684	내 생에 아름다운(뷰티인사이드OST) - K.Will
+2025-12-01	OST(ost)	rank=83	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2025-12-01	OST(ost)	rank=97	num_tj=62026	사랑아(내남자의여자OST) - The One
+2025-12-01	OST(ost)	rank=98	num_tj=93771	Butter-Fly(디지몬어드벤처OST) - 전영호
+2025-12-01	락/메탈(rock_metal)	rank=22	num_tj=34687	안아줘 - 정준일
+2025-12-01	락/메탈(rock_metal)	rank=35	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2025-12-01	락/메탈(rock_metal)	rank=37	num_tj=53705	노래방에서 - 장범준
+2025-12-01	락/메탈(rock_metal)	rank=42	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2025-12-01	락/메탈(rock_metal)	rank=64	num_tj=64573	사랑하게 될 거야 - 한로로
+2025-12-01	락/메탈(rock_metal)	rank=75	num_tj=99783	사계(하루살이) - MC THE MAX
+2025-12-01	락/메탈(rock_metal)	rank=80	num_tj=62004	가시 - 버즈
+2025-12-01	락/메탈(rock_metal)	rank=90	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2025-12-01	락/메탈(rock_metal)	rank=94	num_tj=64372	HAPPY - 데이식스
+2025-12-01	랩/힙합(rap_hiphop)	rank=7	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2025-12-01	랩/힙합(rap_hiphop)	rank=46	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2025-12-01	랩/힙합(rap_hiphop)	rank=68	num_tj=29215	Bae Bae - 빅뱅
+2025-12-01	랩/힙합(rap_hiphop)	rank=70	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2025-12-01	랩/힙합(rap_hiphop)	rank=72	num_tj=98596	시간이 들겠지 - 로꼬(Feat.콜드)
+2025-12-01	랩/힙합(rap_hiphop)	rank=81	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2025-12-01	랩/힙합(rap_hiphop)	rank=87	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2025-12-01	랩/힙합(rap_hiphop)	rank=92	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2025-12-01	랩/힙합(rap_hiphop)	rank=93	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2025-12-01	랩/힙합(rap_hiphop)	rank=100	num_tj=87674	I Feel Good - BOYNEXTDOOR
+2025-12-01	R&B/어반(rnb_urban)	rank=24	num_tj=98524	가을 타나 봐 - 바이브
+2025-12-01	R&B/어반(rnb_urban)	rank=31	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2025-12-01	R&B/어반(rnb_urban)	rank=49	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2025-12-01	R&B/어반(rnb_urban)	rank=68	num_tj=62229	보여줄게 - 에일리
+2025-12-01	R&B/어반(rnb_urban)	rank=74	num_tj=62230	눈, 코, 입 - 태양
+2025-12-01	R&B/어반(rnb_urban)	rank=77	num_tj=62025	벌써 일년 - 브라운아이즈
+2025-12-01	R&B/어반(rnb_urban)	rank=80	num_tj=62055	Timeless - SG워너비
+2025-12-01	R&B/어반(rnb_urban)	rank=84	num_tj=62030	...사랑했잖아... - 린
+2025-12-01	R&B/어반(rnb_urban)	rank=90	num_tj=62222	야생화 - 박효신
+2026-01-01	종합(all)	rank=32	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2026-01-01	종합(all)	rank=48	num_tj=91507	포장마차 - 황인욱
+2026-01-01	종합(all)	rank=70	num_tj=98499	이별하러 가는 길 - 임한별
+2026-01-01	종합(all)	rank=79	num_tj=34687	안아줘 - 정준일
+2026-01-01	종합(all)	rank=84	num_tj=62438	Tears - 소찬휘
+2026-01-01	가요(kpop)	rank=29	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2026-01-01	가요(kpop)	rank=42	num_tj=91507	포장마차 - 황인욱
+2026-01-01	가요(kpop)	rank=64	num_tj=98499	이별하러 가는 길 - 임한별
+2026-01-01	가요(kpop)	rank=72	num_tj=34687	안아줘 - 정준일
+2026-01-01	가요(kpop)	rank=77	num_tj=62438	Tears - 소찬휘
+2026-01-01	가요(kpop)	rank=92	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2026-01-01	POP(pop)	rank=10	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2026-01-01	POP(pop)	rank=14	num_tj=23190	2002 - Anne-Marie
+2026-01-01	POP(pop)	rank=18	num_tj=7761	Lemon tree - Fool's Garden
+2026-01-01	발라드(ballad)	rank=14	num_tj=96763	꿈속에 너 - 에이치코드(Feat.전상근)
+2026-01-01	발라드(ballad)	rank=23	num_tj=91507	포장마차 - 황인욱
+2026-01-01	발라드(ballad)	rank=36	num_tj=98499	이별하러 가는 길 - 임한별
+2026-01-01	발라드(ballad)	rank=90	num_tj=29456	If You - 빅뱅
+2026-01-01	댄스(dance)	rank=7	num_tj=62438	Tears - 소찬휘
+2026-01-01	댄스(dance)	rank=10	num_tj=59015	뱅뱅뱅 (Bang Bang Bang) - 빅뱅
+2026-01-01	댄스(dance)	rank=15	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2026-01-01	댄스(dance)	rank=23	num_tj=59014	맨정신 - 빅뱅
+2026-01-01	댄스(dance)	rank=24	num_tj=34174	예술이야 - 싸이
+2026-01-01	댄스(dance)	rank=27	num_tj=59029	Fantastic Baby - 빅뱅
+2026-01-01	댄스(dance)	rank=28	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2026-01-01	댄스(dance)	rank=39	num_tj=59077	불장난 - 블랙핑크
+2026-01-01	댄스(dance)	rank=40	num_tj=59027	챔피언 - 싸이
+2026-01-01	댄스(dance)	rank=69	num_tj=62258	애상 - 쿨
+2026-01-01	댄스(dance)	rank=79	num_tj=59078	마지막처럼 - 블랙핑크
+2026-01-01	댄스(dance)	rank=81	num_tj=62370	8282 - 다비치
+2026-01-01	댄스(dance)	rank=93	num_tj=59001	강남스타일 - 싸이
+2026-01-01	댄스(dance)	rank=94	num_tj=64581	Soda Pop(KPop Demon Hunters OST) - Saja Boys
+2026-01-01	댄스(dance)	rank=99	num_tj=62479	잘못된 만남 - 김건모
+2026-01-01	트로트(trot)	rank=82	num_tj=62733	초혼 - 장윤정
+2026-01-01	포크(folk)	rank=15	num_tj=93799	첫사랑 - 백아
+2026-01-01	포크(folk)	rank=26	num_tj=62326	스토커 - 10CM
+2026-01-01	포크(folk)	rank=46	num_tj=62262	애상 - 10CM
+2026-01-01	포크(folk)	rank=52	num_tj=93773	그라데이션 - 10CM
+2026-01-01	포크(folk)	rank=55	num_tj=64383	숲 - 최유리
+2026-01-01	포크(folk)	rank=62	num_tj=53754	나만, 봄 - 볼빨간사춘기
+2026-01-01	포크(folk)	rank=73	num_tj=62553	봄봄봄 - 로이킴
+2026-01-01	포크(folk)	rank=83	num_tj=62116	이등병의 편지 - 김광석
+2026-01-01	포크(folk)	rank=93	num_tj=53755	별 보러 갈래? - 볼빨간사춘기
+2026-01-01	포크(folk)	rank=99	num_tj=62349	봄이좋냐?? - 10CM
+2026-01-01	OST(ost)	rank=26	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2026-01-01	OST(ost)	rank=34	num_tj=18446	우리의 꿈(원피스 OP) - 코요태
+2026-01-01	OST(ost)	rank=42	num_tj=64579	Golden(KPop Demon Hunters OST) - HUNTR/X
+2026-01-01	OST(ost)	rank=48	num_tj=48943	상사화(역적:백성을훔친도적OST) - 안예은
+2026-01-01	OST(ost)	rank=61	num_tj=91866	안녕(호텔델루나OST) - 폴킴
+2026-01-01	OST(ost)	rank=67	num_tj=98684	내 생에 아름다운(뷰티인사이드OST) - K.Will
+2026-01-01	OST(ost)	rank=70	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2026-01-01	OST(ost)	rank=72	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2026-01-01	OST(ost)	rank=100	num_tj=62026	사랑아(내남자의여자OST) - The One
+2026-01-01	락/메탈(rock_metal)	rank=26	num_tj=34687	안아줘 - 정준일
+2026-01-01	락/메탈(rock_metal)	rank=37	num_tj=15124	질풍가도(쾌걸!근육맨2세여는노래) - 유정석
+2026-01-01	락/메탈(rock_metal)	rank=40	num_tj=53705	노래방에서 - 장범준
+2026-01-01	락/메탈(rock_metal)	rank=44	num_tj=53651	주저하는 연인들을 위해 - 잔나비
+2026-01-01	락/메탈(rock_metal)	rank=64	num_tj=64573	사랑하게 될 거야 - 한로로
+2026-01-01	락/메탈(rock_metal)	rank=67	num_tj=99783	사계(하루살이) - MC THE MAX
+2026-01-01	락/메탈(rock_metal)	rank=80	num_tj=62004	가시 - 버즈
+2026-01-01	락/메탈(rock_metal)	rank=95	num_tj=62002	응급실(쾌걸춘향OST) - izi
+2026-01-01	락/메탈(rock_metal)	rank=96	num_tj=64372	HAPPY - 데이식스
+2026-01-01	랩/힙합(rap_hiphop)	rank=4	num_tj=59017	삐딱하게(Crooked) - G-DRAGON
+2026-01-01	랩/힙합(rap_hiphop)	rank=48	num_tj=98751	수퍼비와 - 수퍼비(Feat.비와이)(Prod. By 비와이)
+2026-01-01	랩/힙합(rap_hiphop)	rank=64	num_tj=29215	Bae Bae - 빅뱅
+2026-01-01	랩/힙합(rap_hiphop)	rank=67	num_tj=62234	죽일 놈(Guilty) - 다이나믹듀오
+2026-01-01	랩/힙합(rap_hiphop)	rank=70	num_tj=59072	사랑을 했다 (LOVE SCENARIO) - iKON(아이콘)
+2026-01-01	랩/힙합(rap_hiphop)	rank=86	num_tj=98596	시간이 들겠지 - 로꼬(Feat.콜드)
+2026-01-01	랩/힙합(rap_hiphop)	rank=96	num_tj=62268	자니 - 프라이머리(Feat.다이나믹듀오)
+2026-01-01	랩/힙합(rap_hiphop)	rank=97	num_tj=62261	고백(Go Back) - 다이나믹듀오
+2026-01-01	랩/힙합(rap_hiphop)	rank=98	num_tj=62427	Ballerino - 리쌍(Feat.알리)
+2026-01-01	R&B/어반(rnb_urban)	rank=28	num_tj=23363	Speechless(Aladdin OST) - Naomi Scott
+2026-01-01	R&B/어반(rnb_urban)	rank=41	num_tj=98524	가을 타나 봐 - 바이브
+2026-01-01	R&B/어반(rnb_urban)	rank=43	num_tj=64462	시작의 아이 - 마크툽(MAKTUB)
+2026-01-01	R&B/어반(rnb_urban)	rank=57	num_tj=62229	보여줄게 - 에일리
+2026-01-01	R&B/어반(rnb_urban)	rank=69	num_tj=62030	...사랑했잖아... - 린
+2026-01-01	R&B/어반(rnb_urban)	rank=74	num_tj=62025	벌써 일년 - 브라운아이즈
+2026-01-01	R&B/어반(rnb_urban)	rank=76	num_tj=62230	눈, 코, 입 - 태양
+2026-01-01	R&B/어반(rnb_urban)	rank=78	num_tj=62055	Timeless - SG워너비
+2026-01-01	R&B/어반(rnb_urban)	rank=91	num_tj=62113	그런일은 - 박화요비
+2026-01-01	R&B/어반(rnb_urban)	rank=99	num_tj=59008	눈, 코, 입 - 태양

--- a/packages/crawling/src/cron/crawlTjChart.ts
+++ b/packages/crawling/src/cron/crawlTjChart.ts
@@ -1,0 +1,61 @@
+import { endOfMonth, format, startOfMonth, subMonths } from 'date-fns';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+
+import { getSongsAllWithTjDB } from '@/supabase/getDB';
+import { postTjChartRankingsDB } from '@/supabase/postDB';
+import { STR_TYPE_LABEL, StrType, TjChartRankingInsert } from '@/types';
+import {
+  buildSongIdByNumTjMap,
+  fetchTjChart,
+  logChartTable,
+  matchChartRows,
+} from '@/utils/tjChart';
+
+dotenv.config();
+
+const UNMATCHED_LOG_FILE = path.join('src', 'assets', 'tjChartUnmatched.txt');
+
+const targetMonth = subMonths(new Date(), 1);
+const searchStartDate = format(startOfMonth(targetMonth), 'yyyy-MM-dd');
+const searchEndDate = format(endOfMonth(targetMonth), 'yyyy-MM-dd');
+const chartMonth = format(startOfMonth(targetMonth), 'yyyy-MM-dd');
+
+console.log(`📅 대상 월: ${chartMonth} (${searchStartDate} ~ ${searchEndDate})`);
+
+// 1. num_tj 매칭을 위해 전체 곡을 Map으로 로드
+const allSongs = await getSongsAllWithTjDB();
+const songIdByNumTj = buildSongIdByNumTjMap(allSongs);
+console.log(`📦 DB 곡 ${allSongs.length}개 로드 (num_tj 보유: ${songIdByNumTj.size}개)`);
+
+const rows: TjChartRankingInsert[] = [];
+const unmatched: string[] = [];
+
+for (const strType of Object.values(StrType)) {
+  console.log(`📊 [${STR_TYPE_LABEL[strType]}] 차트 조회 중...`);
+  const items = await fetchTjChart(strType, searchStartDate, searchEndDate);
+
+  logChartTable(chartMonth, strType, items, songIdByNumTj, 100);
+
+  const { rows: matchedRows, unmatched: unmatchedLines } = matchChartRows(
+    items,
+    chartMonth,
+    strType,
+    songIdByNumTj,
+  );
+  rows.push(...matchedRows);
+  unmatched.push(...unmatchedLines);
+}
+
+console.log(`✅ 매칭 완료: ${rows.length}건, ⚠️ 미매칭: ${unmatched.length}건`);
+
+if (rows.length > 0) {
+  const success = await postTjChartRankingsDB(rows);
+  console.log(success ? '💾 Supabase 저장 완료' : '❌ Supabase 저장 실패');
+}
+
+if (unmatched.length > 0) {
+  fs.appendFileSync(UNMATCHED_LOG_FILE, unmatched.join('\n') + '\n', 'utf-8');
+  console.log(`📝 미매칭 목록 기록: ${UNMATCHED_LOG_FILE}`);
+}

--- a/packages/crawling/src/cron/crawlTjChartBackfill.ts
+++ b/packages/crawling/src/cron/crawlTjChartBackfill.ts
@@ -1,0 +1,77 @@
+import { eachMonthOfInterval, endOfMonth, format, parse, startOfMonth } from 'date-fns';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+
+import { getSongsAllWithTjDB } from '@/supabase/getDB';
+import { postTjChartRankingsDB } from '@/supabase/postDB';
+import { STR_TYPE_LABEL, StrType, TjChartRankingInsert } from '@/types';
+import {
+  buildSongIdByNumTjMap,
+  fetchTjChart,
+  logChartTable,
+  matchChartRows,
+} from '@/utils/tjChart';
+
+dotenv.config();
+
+const UNMATCHED_LOG_FILE = path.join('src', 'assets', 'tjChartBackfillUnmatched.txt');
+
+// 백필 대상 기간 (직접 지정: YYYY-MM 형식, 양 끝 월 포함)
+const BACKFILL_START_MONTH = '2025-01';
+const BACKFILL_END_MONTH = '2026-01';
+
+const targetMonths = eachMonthOfInterval({
+  start: parse(BACKFILL_START_MONTH, 'yyyy-MM', new Date()),
+  end: parse(BACKFILL_END_MONTH, 'yyyy-MM', new Date()),
+});
+
+console.log(
+  `📅 백필 대상: ${targetMonths.length}개월 (${BACKFILL_START_MONTH} ~ ${BACKFILL_END_MONTH})`,
+);
+
+// 1. num_tj 매칭을 위해 전체 곡을 Map으로 로드
+const allSongs = await getSongsAllWithTjDB();
+const songIdByNumTj = buildSongIdByNumTjMap(allSongs);
+console.log(`📦 DB 곡 ${allSongs.length}개 로드 (num_tj 보유: ${songIdByNumTj.size}개)`);
+
+const rows: TjChartRankingInsert[] = [];
+const unmatched: string[] = [];
+
+for (const targetMonth of targetMonths) {
+  const searchStartDate = format(startOfMonth(targetMonth), 'yyyy-MM-dd');
+  const searchEndDate = format(endOfMonth(targetMonth), 'yyyy-MM-dd');
+  const chartMonth = format(startOfMonth(targetMonth), 'yyyy-MM-dd');
+
+  for (const strType of Object.values(StrType)) {
+    console.log(`📊 [${chartMonth} / ${STR_TYPE_LABEL[strType]}] 차트 조회 중...`);
+    const items = await fetchTjChart(strType, searchStartDate, searchEndDate);
+
+    logChartTable(chartMonth, strType, items, songIdByNumTj, 10);
+
+    const { rows: monthRows, unmatched: unmatchedLines } = matchChartRows(
+      items,
+      chartMonth,
+      strType,
+      songIdByNumTj,
+    );
+    rows.push(...monthRows);
+    unmatched.push(...unmatchedLines);
+
+    if (monthRows.length > 0) {
+      const success = await postTjChartRankingsDB(monthRows);
+      console.log(
+        success
+          ? `💾 [${chartMonth} / ${STR_TYPE_LABEL[strType]}] Supabase 저장 완료 (${monthRows.length}건)`
+          : `❌ [${chartMonth} / ${STR_TYPE_LABEL[strType]}] Supabase 저장 실패`,
+      );
+    }
+  }
+}
+
+console.log(`✅ 매칭 완료: ${rows.length}건, ⚠️ 미매칭: ${unmatched.length}건`);
+
+if (unmatched.length > 0) {
+  fs.appendFileSync(UNMATCHED_LOG_FILE, unmatched.join('\n') + '\n', 'utf-8');
+  console.log(`📝 미매칭 목록 기록: ${UNMATCHED_LOG_FILE}`);
+}

--- a/packages/crawling/src/supabase/postDB.ts
+++ b/packages/crawling/src/supabase/postDB.ts
@@ -1,4 +1,4 @@
-import { LogData, Song } from '@/types';
+import { LogData, Song, TjChartRankingInsert } from '@/types';
 
 import { getClient } from './getClient';
 
@@ -59,6 +59,20 @@ export async function postSongTagsDB(songId: string, tagIds: number[]) {
   const { error } = await supabase.from('song_tags').insert(rows);
   if (error) {
     console.error('postSongTagsDB error:', error);
+    return false;
+  }
+  return true;
+}
+
+export async function postTjChartRankingsDB(rows: TjChartRankingInsert[]) {
+  const supabase = getClient();
+
+  const { error } = await supabase
+    .from('chart_rankings')
+    .upsert(rows, { onConflict: 'chart_month,type,rank' });
+
+  if (error) {
+    console.error('postTjChartRankingsDB error:', error);
     return false;
   }
   return true;

--- a/packages/crawling/src/types.ts
+++ b/packages/crawling/src/types.ts
@@ -25,3 +25,79 @@ export interface LogData<T> {
   success: T[];
   failed: { item: T; error: any }[];
 }
+
+// TJ 공식 차트(topAndHot100) 장르 구분값 (DB 저장용, 영어)
+// 참고: https://www.tjmedia.com/chart/top100
+export enum StrType {
+  All = 'all',
+  Kpop = 'kpop',
+  Pop = 'pop',
+  Jpop = 'jpop',
+  Ballad = 'ballad',
+  Dance = 'dance',
+  Trot = 'trot',
+  Folk = 'folk',
+  Ost = 'ost',
+  RockMetal = 'rock_metal',
+  RapHiphop = 'rap_hiphop',
+  RnbUrban = 'rnb_urban',
+}
+
+export const STR_TYPE_LABEL: Record<StrType, string> = {
+  [StrType.All]: '종합',
+  [StrType.Kpop]: '가요',
+  [StrType.Pop]: 'POP',
+  [StrType.Jpop]: 'JPOP',
+  [StrType.Ballad]: '발라드',
+  [StrType.Dance]: '댄스',
+  [StrType.Trot]: '트로트',
+  [StrType.Folk]: '포크',
+  [StrType.Ost]: 'OST',
+  [StrType.RockMetal]: '락/메탈',
+  [StrType.RapHiphop]: '랩/힙합',
+  [StrType.RnbUrban]: 'R&B/어반',
+};
+
+// TJ topAndHot100 API가 요구하는 strType 파라미터 값 (숫자 문자열)
+export const STR_TYPE_API_PARAM: Record<StrType, string> = {
+  [StrType.All]: '',
+  [StrType.Kpop]: '1',
+  [StrType.Pop]: '2',
+  [StrType.Jpop]: '3',
+  [StrType.Ballad]: '4',
+  [StrType.Dance]: '5',
+  [StrType.Trot]: '6',
+  [StrType.Folk]: '7',
+  [StrType.Ost]: '8',
+  [StrType.RockMetal]: '9',
+  [StrType.RapHiphop]: '10',
+  [StrType.RnbUrban]: '11',
+};
+
+export interface TjChartItem {
+  rank: string;
+  pro: number;
+  indexTitle: string;
+  indexSong: string;
+  word: string;
+  com: string;
+  mv_yn: string;
+  imgthumb_path: string;
+  icongubun: string;
+}
+
+export interface TjChartApiResponse {
+  resultCode: string;
+  resultMsg: string;
+  resultData: {
+    itemsTotalCount: number;
+    items: TjChartItem[];
+  };
+}
+
+export interface TjChartRankingInsert {
+  chart_month: string;
+  type: StrType;
+  rank: number;
+  song_id: string;
+}

--- a/packages/crawling/src/utils/tjChart.ts
+++ b/packages/crawling/src/utils/tjChart.ts
@@ -1,0 +1,99 @@
+import axios from 'axios';
+
+import {
+  STR_TYPE_API_PARAM,
+  STR_TYPE_LABEL,
+  Song,
+  StrType,
+  TjChartApiResponse,
+  TjChartItem,
+  TjChartRankingInsert,
+} from '@/types';
+
+export async function fetchTjChart(
+  strType: StrType,
+  searchStartDate: string,
+  searchEndDate: string,
+) {
+  const { data } = await axios.get<TjChartApiResponse>(
+    'https://www.tjmedia.com/legacy/api/topAndHot100',
+    {
+      params: {
+        chartType: 'TOP',
+        searchStartDate,
+        searchEndDate,
+        strType: STR_TYPE_API_PARAM[strType],
+      },
+    },
+  );
+
+  if (data.resultCode !== '99') {
+    throw new Error(`TJ 차트 API 실패 (strType=${strType}): ${data.resultMsg}`);
+  }
+
+  return data.resultData.items;
+}
+
+export function buildSongIdByNumTjMap(songs: Song[]) {
+  const songIdByNumTj = new Map<string, string>();
+  for (const song of songs) {
+    if (song.num_tj && song.id) {
+      songIdByNumTj.set(song.num_tj, song.id);
+    }
+  }
+  return songIdByNumTj;
+}
+
+export function logChartTable(
+  chartMonth: string,
+  strType: StrType,
+  items: TjChartItem[],
+  songIdByNumTj: Map<string, string>,
+  limit: number,
+) {
+  const target = [...items]
+    .sort((a, b) => Number(a.rank) - Number(b.rank))
+    .filter(item => Number(item.rank) <= limit);
+
+  console.log(`🏆 [${chartMonth} / ${STR_TYPE_LABEL[strType]}] TOP ${limit}`);
+  console.table(
+    target.map(item => ({
+      순위: item.rank,
+      곡명: item.indexSong,
+      아티스트: item.indexTitle,
+      num_tj: item.pro,
+      매칭: songIdByNumTj.has(String(item.pro)) ? 'O' : 'X',
+    })),
+  );
+}
+
+export function matchChartRows(
+  items: TjChartItem[],
+  chartMonth: string,
+  strType: StrType,
+  songIdByNumTj: Map<string, string>,
+) {
+  const rows: TjChartRankingInsert[] = [];
+  const unmatched: string[] = [];
+
+  for (const item of items) {
+    const numTj = String(item.pro);
+    const songId = songIdByNumTj.get(numTj);
+
+    if (!songId) {
+      unmatched.push(
+        `${chartMonth}\t${STR_TYPE_LABEL[strType]}(${strType})\trank=${item.rank}\tnum_tj=${numTj}\t${item.indexTitle} - ${item.indexSong}`,
+      );
+      continue;
+    }
+
+    rows.push({
+      chart_month: chartMonth,
+      type: strType,
+      rank: Number(item.rank),
+      song_id: songId,
+    });
+  }
+
+  return { rows, unmatched };
+}


### PR DESCRIPTION
## 📌 PR 제목

### Feat : TJ 공식 차트 API 연동으로 popular 페이지 개편

## 📌 변경 사항

- TJ미디어 공식 `topAndHot100` API를 장르별로 크롤링하는 `crawlTjChart.ts` 추가 (매달 지난달 기준, GitHub Actions로 매달 1일 KST 10시 자동 실행)
- 특정 기간(월 단위 반복)을 일괄 등록하는 `crawlTjChartBackfill.ts` 추가, 조회 시마다 순위 표(`console.table`)와 저장 결과를 즉시 로그로 확인 가능
- 크롤링 공통 로직(API 호출/곡 매칭/순위 로깅)을 `packages/crawling/src/utils/tjChart.ts`로 추출해 두 크론 스크립트에서 재사용
- `chart_rankings` 테이블 upsert용 `postTjChartRankingsDB` 추가, `StrType` enum 및 TJ API 응답 타입 정의
- 웹앱: `GET /api/tj-chart` 라우트(월/장르 파라미터로 `chart_rankings` + `songs` 조인 조회) 및 `lib/api/tjChart.ts`, `queries/tjChartQuery.ts`, `types/tjChart.ts` 추가
- `/popular` 페이지의 기존 `PopularRankingList`(포인트 기반 추천)를 월/장르 선택 가능한 `TjChartRankingList`로 교체 (기존 엄지척/thumb 시스템 코드는 그대로 유지)

## 💬 추가 참고 사항

- HOT100은 이번 범위에서 제외, TOP100만 수집
- `num_tj` 매칭 실패 곡은 저장하지 않고 `src/assets/tjChartUnmatched.txt`(정기 크롤링) / `tjChartBackfillUnmatched.txt`(백필)에만 기록
- close #295